### PR TITLE
Files input

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,13 @@ Changelog
 #########
 
 ---
+0.6
+---
+* ``input_files`` config option now raises a deprecation warning and will be replaced with ``input``
+* abstract ``input`` types are now available which is necessary for additional non-file based input drivers such as DB connections
+
+
+---
 0.5
 ---
 * introduced iterable input data groups

--- a/mapchete/__init__.py
+++ b/mapchete/__init__.py
@@ -585,14 +585,14 @@ class MapcheteProcess(object):
             else:
                 return existing_tile.read(**kwargs)
 
-    def open(self, input_file, **kwargs):
+    def open(self, input_id, **kwargs):
         """
         Open input data.
 
         Parameters
         ----------
-        input_file : string
-            file identifier from configuration file or file path
+        input_id : string
+            input identifier from configuration file or file path
         kwargs : driver specific parameters (e.g. resampling)
 
         Returns
@@ -600,12 +600,12 @@ class MapcheteProcess(object):
         tiled input data : InputTile
             reprojected input data within tile
         """
-        if not isinstance(input_file, str):
-            return input_file.open(self.tile, **kwargs)
-        if input_file not in self.params["input_files"]:
+        if not isinstance(input_id, str):
+            return input_id.open(self.tile, **kwargs)
+        if input_id not in self.params["input"]:
             raise ValueError(
-                "%s not found in config as input file" % input_file)
-        return self.params["input_files"][input_file].open(self.tile, **kwargs)
+                "%s not found in config as input file" % input_id)
+        return self.params["input"][input_id].open(self.tile, **kwargs)
 
     def hillshade(
         self, elevation, azimuth=315.0, altitude=45.0, z=1.0, scale=1.0

--- a/mapchete/config/_parse_input.py
+++ b/mapchete/config/_parse_input.py
@@ -19,9 +19,8 @@ LOGGER = logging.getLogger(__name__)
 
 def input_at_zoom(process, name, element, zoom):
     """Get readers and bounding boxes for input."""
-    print name, element
     LOGGER.debug("get input items metadata for zoom %s" % zoom)
-    # case where single input files is provided by CLI
+    # case where a single input file is provided by CLI
     if element == "from_command_line":
         element = {"input_file": None}
     elif element is None:
@@ -29,35 +28,33 @@ def input_at_zoom(process, name, element, zoom):
             process.process_pyramid.left, process.process_pyramid.bottom,
             process.process_pyramid.right, process.process_pyramid.top
         )
-    # get input files for current zoom level
-    print name, element
-    files_tree = process._element_at_zoom(name, element, zoom)
-    print files_tree
+    # get inputs for current zoom level
+    input_tree = process._element_at_zoom(name, element, zoom)
     # convert tree to key-value object, where path within tree is the key
-    files_flat = _flatten_tree(files_tree)
-    # select files not yet cached
-    new_files = []
-    cached_files = {}
-    for name, path in files_flat:
-        if path in process._input_cache:
-            cached_files[name] = process._input_cache[path]
+    input_flat = _flatten_tree(input_tree)
+    # select inputs not yet cached
+    new_inputs = []
+    cached_inputs = {}
+    for name, input_obj in input_flat:
+        if str(input_obj) in process._input_cache:
+            cached_inputs[name] = process._input_cache[str(input_obj)]
         else:
-            new_files.append((name, path))
+            new_inputs.append((name, input_obj))
 
-    LOGGER.debug("%s new files to analyze", len(new_files))
-    if len(new_files) >= cpu_count():
-        # analyze files in parallel
+    LOGGER.debug("%s new inputs to analyze", len(new_inputs))
+    if len(new_inputs) >= cpu_count():
+        # analyze inputs in parallel
         start = time.time()
         f = partial(
-            _file_worker, process.config_dir, process.process_pyramid,
+            _input_worker, process.config_dir, process.process_pyramid,
             process.pixelbuffer
         )
         pool = Pool()
         try:
-            analyzed_files = {
-                key: location_reader
-                for key, location_reader in pool.imap_unordered(
-                    f, new_files, chunksize=8
+            analyzed_inputs = {
+                key: input_obj_reader
+                for key, input_obj_reader in pool.imap_unordered(
+                    f, new_inputs, chunksize=8
                 )
             }
         except KeyboardInterrupt:
@@ -72,25 +69,25 @@ def input_at_zoom(process, name, element, zoom):
             pool.join()
 
         LOGGER.debug(
-            "parallel file parsing: %ss" % round(time.time() - start, 3))
+            "parallel input parsing: %ss" % round(time.time() - start, 3))
     else:
         start = time.time()
-        analyzed_files = {
-            k: _file_worker(
+        analyzed_inputs = {
+            k: _input_worker(
                 process.config_dir, process.process_pyramid,
                 process.pixelbuffer, (k, v)
             )[1]
-            for k, v in new_files
+            for k, v in new_inputs
         }
         LOGGER.debug(
-            "sequential file parsing: %ss" % round(time.time() - start, 3))
+            "sequential input parsing: %ss" % round(time.time() - start, 3))
 
-    # create original dicionary with file readers
+    # create original dicionary with input readers
     analyzed_readers = {}
-    for name, (location, reader) in analyzed_files.iteritems():
-        process._input_cache[location] = reader
+    for name, (input_obj, reader) in analyzed_inputs.iteritems():
+        process._input_cache[str(input_obj)] = reader
         analyzed_readers[name] = reader
-    analyzed_readers.update(cached_files)
+    analyzed_readers.update(cached_inputs)
     input_ = _unflatten_tree(analyzed_readers)
 
     # collect boundding boxes of inputs
@@ -100,7 +97,7 @@ def input_at_zoom(process, name, element, zoom):
         if reader is not None
     ]
     if input_areas:
-        LOGGER.debug("intersect input files bounding boxes")
+        LOGGER.debug("intersect input bounding boxes")
         id_ = ImmutableSet([dumps(i) for i in input_areas])
         if id_ not in process._process_area_cache:
             process._process_area_cache[id_] = unary_union(input_areas)
@@ -119,7 +116,7 @@ def _flatten_tree(tree, old_path=None):
     flat_tree = []
     for key, value in tree.iteritems():
         new_path = "/".join([old_path, key]) if old_path else key
-        if isinstance(value, dict):
+        if isinstance(value, dict) and "format" not in value:
             flat_tree.extend(_flatten_tree(value, old_path=new_path))
         else:
             flat_tree.append((new_path, value))
@@ -149,25 +146,38 @@ def _unflatten_tree(flat):
     return tree
 
 
-def _file_worker(conf_dir, pyramid, pixelbuffer, kv):
-    key, location = kv
-    if location not in ["none", "None", None, ""]:
-        # prepare input files metadata
-        LOGGER.debug("read metadata from %s" % location)
-        # get absolute paths if not remote
-        path = location if location.startswith(
-            ("s3://", "https://", "http://")) else os.path.normpath(
-            os.path.join(conf_dir, location)
-        )
-        LOGGER.debug("load input reader for file %s" % location)
-        _input_reader = load_input_reader(dict(
+def _input_worker(conf_dir, pyramid, pixelbuffer, kv):
+    key, input_obj = kv
+    if input_obj not in ["none", "None", None, ""]:
+        # prepare input metadata
+        LOGGER.debug("read metadata from %s" % input_obj)
+        # for single file inputs
+        if isinstance(input_obj, str):
+            # get absolute paths if not remote
+            path = input_obj if input_obj.startswith(
+                ("s3://", "https://", "http://")) else os.path.normpath(
+                os.path.join(conf_dir, input_obj)
+            )
+            LOGGER.debug("load input reader for file %s" % input_obj)
+            _input_reader = load_input_reader(dict(
                 path=path, pyramid=pyramid, pixelbuffer=pixelbuffer
-        ))
-        LOGGER.debug(
-            "input reader for file %s is %s" % (location, _input_reader)
-        )
+            ))
+            LOGGER.debug(
+                "input reader for file %s is %s" % (input_obj, _input_reader)
+            )
+        # for abstract inputs
+        elif isinstance(input_obj, dict):
+            LOGGER.debug("load input reader for abstract input %s" % input_obj)
+            _input_reader = load_input_reader(dict(
+                abstract=input_obj, pyramid=pyramid, pixelbuffer=pixelbuffer
+            ))
+            LOGGER.debug(
+                "input reader for abstract input %s is %s" % (
+                    input_obj, _input_reader
+                )
+            )
         # trigger input bounding box caches
         _input_reader.bbox(out_crs=pyramid.crs)
-        return key, (location, _input_reader)
+        return key, (input_obj, _input_reader)
     else:
         return key, (None, None)

--- a/mapchete/errors.py
+++ b/mapchete/errors.py
@@ -19,3 +19,7 @@ class MapcheteProcessOutputError(ValueError):
 
 class MapcheteConfigError(ValueError):
     """Raised when a mapchete process configuration is invalid."""
+
+
+class MapcheteDriverError(Exception):
+    """Raised when a mapchete process configuration is invalid."""

--- a/mapchete/io/vector.py
+++ b/mapchete/io/vector.py
@@ -29,7 +29,8 @@ CRS_BOUNDS = {
 
 
 def reproject_geometry(
-    geometry, src_crs, dst_crs, error_on_clip=False, validity_check=True
+    geometry, src_crs=None, dst_crs=None, error_on_clip=False,
+    validity_check=True
 ):
     """
     Reproject a geometry to target CRS.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ on_rtd = os.environ.get('READTHEDOCS') == 'True'
 
 setup(
     name='mapchete',
-    version='0.5',
+    version='0.6',
     description='tile-based geodata processing',
     author='Joachim Ungar',
     author_email='joachim.ungar@gmail.com',

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -8,6 +8,7 @@ from shapely.wkt import loads
 
 import mapchete
 from mapchete.config import MapcheteConfig
+from mapchete.errors import MapcheteDriverError
 
 
 SCRIPTDIR = os.path.dirname(os.path.realpath(__file__))
@@ -159,6 +160,7 @@ def test_read_input_groups():
     config = MapcheteConfig(
         os.path.join(SCRIPTDIR, "testdata/file_groups.mapchete"))
     input_files = config.at_zoom(0)["input"]
+    print input_files
     assert "file1" in input_files["group1"]
     assert "file2" in input_files["group1"]
     assert "file1" in input_files["group2"]
@@ -195,3 +197,14 @@ def test_input_files_zooms():
     assert os.path.basename(
         input_files["greater_smaller"].path) == "dummy2.tif"
     assert os.path.basename(input_files["equals"].path) == "cleantopo_tl.tif"
+
+
+def test_abstract_input():
+    """Read abstract input definitions."""
+    try:
+        MapcheteConfig(
+            os.path.join(SCRIPTDIR, "testdata/abstract_input.mapchete")
+        )
+        raise Exception
+    except MapcheteDriverError:
+        pass

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -18,7 +18,7 @@ def test_config_zoom5():
     config = MapcheteConfig(os.path.join(SCRIPTDIR, "example.mapchete"))
     dummy2_abspath = os.path.join(SCRIPTDIR, "testdata/dummy2.tif")
     zoom5 = config.at_zoom(5)
-    input_files = zoom5["input_files"]
+    input_files = zoom5["input"]
     assert input_files["file1"] is None
     assert input_files["file2"].path == dummy2_abspath
     assert zoom5["some_integer_parameter"] == 12
@@ -33,7 +33,7 @@ def test_config_zoom11():
     dummy1_abspath = os.path.join(SCRIPTDIR, "testdata/dummy1.tif")
     dummy2_abspath = os.path.join(SCRIPTDIR, "testdata/dummy2.tif")
     zoom11 = config.at_zoom(11)
-    input_files = zoom11["input_files"]
+    input_files = zoom11["input"]
     assert input_files["file1"].path == dummy1_abspath
     assert input_files["file2"].path == dummy2_abspath
     assert zoom11["some_integer_parameter"] == 12
@@ -82,6 +82,16 @@ def test_override_bounds():
     test_polygon = Polygon([
         [3, 1.5], [3, 2], [3.5, 2], [3.5, 1.5], [3, 1.5]])
     assert config.process_area(5).equals(test_polygon)
+
+
+def test_input():
+    """Parse configuration using "input" instead of "input"."""
+    config = yaml.load(
+        open(os.path.join(SCRIPTDIR, "example.mapchete"), "r").read()
+    )
+    # config["input"] = config.pop("input")
+    config["config_dir"] = SCRIPTDIR
+    assert mapchete.open(config)
 
 
 def test_bounds_from_input_files():
@@ -148,7 +158,7 @@ def test_read_input_groups():
     """Read input data groups."""
     config = MapcheteConfig(
         os.path.join(SCRIPTDIR, "testdata/file_groups.mapchete"))
-    input_files = config.at_zoom(0)["input_files"]
+    input_files = config.at_zoom(0)["input"]
     assert "file1" in input_files["group1"]
     assert "file2" in input_files["group1"]
     assert "file1" in input_files["group2"]
@@ -166,22 +176,22 @@ def test_input_files_zooms():
     config = MapcheteConfig(
         os.path.join(SCRIPTDIR, "testdata/files_zooms.mapchete"))
     # zoom 7
-    input_files = config.at_zoom(7)["input_files"]
+    input_files = config.at_zoom(7)["input"]
     assert os.path.basename(
         input_files["greater_smaller"].path) == "dummy1.tif"
     assert os.path.basename(input_files["equals"].path) == "dummy1.tif"
     # zoom 8
-    input_files = config.at_zoom(8)["input_files"]
+    input_files = config.at_zoom(8)["input"]
     assert os.path.basename(
         input_files["greater_smaller"].path) == "dummy1.tif"
     assert os.path.basename(input_files["equals"].path) == "dummy2.tif"
     # zoom 9
-    input_files = config.at_zoom(9)["input_files"]
+    input_files = config.at_zoom(9)["input"]
     assert os.path.basename(
         input_files["greater_smaller"].path) == "dummy2.tif"
     assert os.path.basename(input_files["equals"].path) == "cleantopo_br.tif"
     # zoom 10
-    input_files = config.at_zoom(10)["input_files"]
+    input_files = config.at_zoom(10)["input"]
     assert os.path.basename(
         input_files["greater_smaller"].path) == "dummy2.tif"
     assert os.path.basename(input_files["equals"].path) == "cleantopo_tl.tif"

--- a/test/test_formats.py
+++ b/test/test_formats.py
@@ -40,7 +40,7 @@ def test_mapchete_input():
     """Mapchete process as input for other process."""
     mp = mapchete.open(os.path.join(TESTDATA_DIR, "mapchete_input.mapchete"))
     config = mp.config.at_zoom(5)
-    mp_input = config["input_files"]["file2"].open(
+    mp_input = config["input"]["file2"].open(
         mp.get_process_tiles(5).next())
     assert mp_input.is_empty()
 

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -35,7 +35,7 @@ def test_read_raster_window():
     zoom = 8
     config = MapcheteConfig(
         os.path.join(SCRIPTDIR, "testdata/minmax_zoom.mapchete"))
-    rasterfile = config.at_zoom(7)["input_files"]["file1"]
+    rasterfile = config.at_zoom(7)["input"]["file1"]
     dummy1_bbox = rasterfile.bbox()
 
     pixelbuffer = 5
@@ -281,7 +281,7 @@ def test_read_vector_window():
     zoom = 4
     config = MapcheteConfig(
         os.path.join(SCRIPTDIR, "testdata/geojson.mapchete"))
-    vectorfile = config.at_zoom(zoom)["input_files"]["file1"]
+    vectorfile = config.at_zoom(zoom)["input"]["file1"]
     pixelbuffer = 5
     tile_pyramid = BufferedTilePyramid("geodetic", pixelbuffer=pixelbuffer)
     tiles = tile_pyramid.tiles_from_geom(vectorfile.bbox(), zoom)

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -83,7 +83,7 @@ def test_write_raster_window():
             with rasterio.open(path, 'r') as src:
                 assert src.read().any()
                 assert src.meta["driver"] == out_profile["driver"]
-                assert src.affine == tile.affine
+                assert src.transform == tile.affine
                 if out_profile["compress"]:
                     assert src.compression == Compression(
                         out_profile["compress"].upper())
@@ -105,7 +105,7 @@ def test_write_raster_window():
             assert src.shape == out_tile.shape
             assert src.read().any()
             assert src.meta["driver"] == out_profile["driver"]
-            assert src.affine == out_profile["affine"]
+            assert src.transform == out_profile["affine"]
     finally:
         shutil.rmtree(path, ignore_errors=True)
 

--- a/test/testdata/abstract_input.mapchete
+++ b/test/testdata/abstract_input.mapchete
@@ -1,0 +1,19 @@
+# mapchete parameters
+process_file: ../example_process.py
+process_minzoom: 0
+process_maxzoom: 5
+input:
+    test_abstract:
+        format: dummy_format
+
+output:
+    type: geodetic
+    dtype: uint16
+    bands: 1
+    format: GTiff
+    path: tmp
+    pixelbuffer: 10
+    # metatiling: 1
+
+pixelbuffer: 10
+metatiling: 8


### PR DESCRIPTION
Using ``input_files`` now raises a deprecation warning.

``input`` works the same way as ``input_files`` but enables the development of additional drivers which require more parameters than just a file path (e.g. db connections etc). These "abstract" input types just require a ``format`` parameter for the driver name.

closing #66 