### PR TITLE
Detatch tile data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,19 @@
 Changelog
 #########
 
+----
+0.10
+----
+* better memory handling by detatching process output data from ``BufferedTile`` objects
+* breaking API changes:
+  * Mapchete.execute() returns raw data instead of tile with data attribute
+  * Mapchete.read() returns raw data instead of tile with data attribute
+  * Mapchete.get_raw_output() returns raw data instead of tile with data attribute
+  * Mapchete.write() requires process_tile and data as arguments
+  * same valid for all other read() and write() functions in drivers & MapcheteProcess object
+* new MapcheteNodataTile exception to indicate an empty process output
+
+
 ---
 0.9
 ---

--- a/mapchete/__init__.py
+++ b/mapchete/__init__.py
@@ -35,7 +35,7 @@ logging.basicConfig(
 LOGGER = logging.getLogger(__name__)
 
 
-__version__ = "0.9"
+__version__ = "0.10"
 
 
 def open(

--- a/mapchete/__init__.py
+++ b/mapchete/__init__.py
@@ -344,9 +344,7 @@ class Mapchete(object):
             if self.config.output.tiles_exist(process_tile):
                 return self._read_existing_output(tile, output_tiles)
             else:
-                return self._process_and_overwrite_output(
-                    tile, process_tile
-                )
+                return self._process_and_overwrite_output(tile, process_tile)
         elif self.config.mode == "overwrite" and not _baselevel_readonly:
             return self._process_and_overwrite_output(tile, process_tile)
 
@@ -535,7 +533,9 @@ class Mapchete(object):
                     child_tile,
                     self.get_raw_output(child_tile, _baselevel_readonly=True)
                 )
-                for child_tile in tile.get_children()
+                for child_tile in self.config.baselevels["tile_pyramid"].tile(
+                    *tile.id
+                ).get_children()
             ])
             process_data = raster.resample_from_array(
                 in_raster=mosaic,

--- a/mapchete/cli/serve.py
+++ b/mapchete/cli/serve.py
@@ -93,7 +93,7 @@ def _tile_response(mp, web_tile, debug):
             abort(500)
 
 
-def _valid_tile_response(mp, web_tile):
-    response = make_response(mp.config.output.for_web(web_tile.data))
+def _valid_tile_response(mp, data):
+    response = make_response(mp.config.output.for_web(data))
     response.cache_control.no_write = True
     return response

--- a/mapchete/errors.py
+++ b/mapchete/errors.py
@@ -27,3 +27,7 @@ class MapcheteDriverError(Exception):
 
 class MapcheteEmptyInputTile(Exception):
     """Generic exception raised by a driver if input tile is empty."""
+
+
+class MapcheteNodataTile(Exception):
+    """Indicates an empty tile."""

--- a/mapchete/io/vector.py
+++ b/mapchete/io/vector.py
@@ -180,14 +180,15 @@ def read_vector_window(input_file, tile, validity_check=True):
         return features
 
 
-def write_vector_window(in_tile, out_schema, out_tile, out_path):
+def write_vector_window(in_data=None, out_schema=None, out_tile=None,
+    out_path=None
+):
     """
     Write features to GeoJSON file.
 
     Parameters
     ----------
-    in_tile : ``BufferedTile``
-        input tile including data
+    in_data : features
     out_schema : dictionary
         output schema for fiona
     out_tile : ``BufferedTile``
@@ -201,10 +202,10 @@ def write_vector_window(in_tile, out_schema, out_tile, out_path):
     except OSError:
         pass
     # Return if tile data is empty
-    if not in_tile.data:
+    if not in_data:
         return
     out_features = []
-    for feature in in_tile.data:
+    for feature in in_data:
         feature_geom = shape(feature["geometry"])
         clipped = feature_geom.intersection(out_tile.bbox)
         out_geom = clipped
@@ -317,25 +318,3 @@ def clean_geometry_type(geometry, target_type, allow_multipart=True):
         return geometry
     else:
         return None
-
-
-def extract_from_tile(in_tile, out_tile):
-    """
-    Extract features from BufferedTile.
-
-    Parameters
-    ----------
-    in_tile : ``BufferedTile``
-    out_tile : ``BufferedTile``
-
-    Returns
-    -------
-    extracted features : list
-    """
-    assert isinstance(in_tile, BufferedTile)
-    assert isinstance(out_tile, BufferedTile)
-    assert isinstance(in_tile.data, list)
-    return [
-        feature
-        for feature in in_tile.data
-        if shape(feature["geometry"]).touches(out_tile.bbox)]

--- a/mapchete/tile.py
+++ b/mapchete/tile.py
@@ -151,12 +151,6 @@ class BufferedTile(Tile):
         tile bounding box as shapely geometry
     pixelbuffer : integer
         pixelbuffer used to create tile
-    data : array or list
-        raster or vector data
-    message : string
-        a place for status messages
-    error : string
-        a place for error messages
     profile : dictionary
         rasterio metadata profile
     """
@@ -167,9 +161,6 @@ class BufferedTile(Tile):
         Tile.__init__(self, tile.tile_pyramid, tile.zoom, tile.row, tile.col)
         self._tile = tile
         self.pixelbuffer = pixelbuffer
-        self.data = None
-        self.message = None
-        self.error = None
 
     @cached_property
     def profile(self):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -205,7 +205,6 @@ def test_read_input_groups():
     config = MapcheteConfig(
         os.path.join(SCRIPTDIR, "testdata/file_groups.mapchete"))
     input_files = config.at_zoom(0)["input"]
-    print input_files
     assert "file1" in input_files["group1"]
     assert "file2" in input_files["group1"]
     assert "file1" in input_files["group2"]

--- a/test/test_formats.py
+++ b/test/test_formats.py
@@ -138,5 +138,3 @@ def test_http_rasters():
     # TODO make tests more performant
     with mapchete.open(config) as mp:
         assert mp.config.process_area(zoom).area > 0
-        # tile = mp.get_raw_output(mp.get_process_tiles(zoom).next())
-        # assert not tile.data.mask.all()

--- a/test/test_formats_geojson.py
+++ b/test/test_formats_geojson.py
@@ -63,14 +63,14 @@ def test_output_data():
         mp = mapchete.open(os.path.join(SCRIPTDIR, "testdata/geojson.mapchete"))
         for tile in mp.get_process_tiles(4):
             # write empty
-            mp.write(tile)
+            mp.write(tile, None)
             # write data
-            output = mp.get_raw_output(tile)
-            mp.write(output)
+            raw_output = mp.get_raw_output(tile)
+            mp.write(tile, raw_output)
             # read data
-            out_tile = mp.config.output.read(tile)
-            assert isinstance(out_tile.data, list)
-            if output.data:
-                assert out_tile.data
+            read_output = mp.config.output.read(tile)
+            assert isinstance(read_output, list)
+            if raw_output:
+                assert read_output
     finally:
         shutil.rmtree(TEMP_DIR, ignore_errors=True)

--- a/test/test_formats_geotiff.py
+++ b/test/test_formats_geotiff.py
@@ -44,18 +44,18 @@ def test_output_data():
     assert isinstance(output.profile(tile), dict)
     # write
     try:
-        tile.data = np.ones((1, ) + tile.shape)*128
-        output.write(tile)
+        data = np.ones((1, ) + tile.shape)*128
+        output.write(tile, data)
         # tiles_exist
         assert output.tiles_exist(tile)
         # read
-        data = output.read(tile).data
+        data = output.read(tile)
         assert isinstance(data, np.ndarray)
         assert not data[0].mask.any()
     finally:
         shutil.rmtree(temp_dir, ignore_errors=True)
     # read empty
-    data = output.read(tile).data
+    data = output.read(tile)
     assert isinstance(data, np.ndarray)
     assert data[0].mask.all()
     # empty

--- a/test/test_formats_png.py
+++ b/test/test_formats_png.py
@@ -41,12 +41,12 @@ def test_output_data():
     assert isinstance(output.profile(tile), dict)
     # write
     try:
-        tile.data = np.ones((1, ) + tile.shape)*128
-        output.write(tile)
+        data = np.ones((1, ) + tile.shape)*128
+        output.write(tile, data)
         # tiles_exist
         assert output.tiles_exist(tile)
         # read
-        data = output.read(tile).data
+        data = output.read(tile)
         assert isinstance(data, np.ndarray)
         assert data.shape[0] == 4
         assert not data[0].mask.any()

--- a/test/test_formats_png_hillshade.py
+++ b/test/test_formats_png_hillshade.py
@@ -43,12 +43,12 @@ def test_output_data():
     assert isinstance(output.profile(tile), dict)
     # write full array
     try:
-        tile.data = np.ones(tile.shape)*128
-        output.write(tile)
+        data = np.ones(tile.shape)*128
+        output.write(tile, data)
         # tiles_exist
         assert output.tiles_exist(tile)
         # read
-        data = output.read(tile).data
+        data = output.read(tile)
         assert isinstance(data, np.ndarray)
         assert not data.mask.any()
     finally:
@@ -56,15 +56,15 @@ def test_output_data():
     # write half masked array
     try:
         half_shape = (tile.shape[0], tile.shape[1]/2)
-        tile.data = ma.masked_array(
+        data = ma.masked_array(
             data=np.ones(tile.shape)*128,
             mask=np.concatenate(
                 [np.zeros(half_shape), np.ones(half_shape)], axis=1))
-        output.write(tile)
+        output.write(tile, data)
         # tiles_exist
         assert output.tiles_exist(tile)
         # read
-        data = output.read(tile).data
+        data = output.read(tile)
         assert isinstance(data, np.ndarray)
         assert not data.mask.all()
         assert data.mask.any()
@@ -76,12 +76,12 @@ def test_output_data():
     tp = BufferedTilePyramid("geodetic")
     tile = tp.tile(5, 5, 5)
     try:
-        tile.data = np.ones(tile.shape)*128
-        output.write(tile)
+        data = np.ones(tile.shape)*128
+        output.write(tile, data)
         # tiles_exist
         assert output.tiles_exist(tile)
         # read
-        data = output.read(tile).data
+        data = output.read(tile)
         assert isinstance(data, np.ndarray)
         assert not data.mask.any()
     finally:
@@ -91,6 +91,6 @@ def test_output_data():
     assert isinstance(empty, ma.MaskedArray)
     assert not empty.any()
     # read non-existing file
-    data = output.read(tile).data
+    data = output.read(tile)
     assert data.mask.all()
     # TODO for_web

--- a/test/test_mapchete.py
+++ b/test/test_mapchete.py
@@ -31,8 +31,7 @@ def test_empty_execute():
         with mapchete.open(
             os.path.join(SCRIPTDIR, "testdata/cleantopo_br.mapchete")
         ) as mp:
-            out_tile = mp.execute((6, 0, 0))
-            assert out_tile.data.mask.all()
+            assert mp.execute((6, 0, 0)).mask.all()
     finally:
         shutil.rmtree(OUT_DIR, ignore_errors=True)
 
@@ -89,7 +88,7 @@ def test_read_existing_output():
         ) as mp:
             tile = mp.get_process_tiles(4).next()
             # process and save
-            mp.write(mp.get_raw_output(tile))
+            mp.write(tile, mp.get_raw_output(tile))
             # read written data from within MapcheteProcess object
             mp_tile = mapchete.MapcheteProcess(
                 tile,
@@ -126,8 +125,7 @@ def test_get_raw_output_outside():
         with mapchete.open(
             os.path.join(SCRIPTDIR, "testdata/cleantopo_br.mapchete")
         ) as mp:
-            out_tile = mp.get_raw_output((6, 0, 0))
-            assert out_tile.data.mask.all()
+            assert mp.get_raw_output((6, 0, 0)).mask.all()
     finally:
         shutil.rmtree(OUT_DIR, ignore_errors=True)
 
@@ -140,8 +138,7 @@ def test_get_raw_output_memory():
             mode="memory"
         ) as mp:
             assert mp.config.mode == "memory"
-            out_tile = mp.get_raw_output((5, 0, 0))
-            assert not out_tile.data.mask.all()
+            assert not mp.get_raw_output((5, 0, 0)).mask.all()
     finally:
         shutil.rmtree(OUT_DIR, ignore_errors=True)
 
@@ -158,22 +155,17 @@ def test_get_raw_output_readonly():
             mode="continue")
 
         # read non-existing data (returns empty)
-        out_tile = readonly_mp.get_raw_output(tile)
-        assert out_tile.data.mask.all()
+        assert readonly_mp.get_raw_output(tile).mask.all()
 
         # try to process and save empty data
-        try:  # TODO
-            readonly_mp.write(readonly_mp.get_raw_output(tile))
-            raise Exception()
-        except ValueError:
-            pass
+        with pytest.raises(ValueError):
+            readonly_mp.write(tile, readonly_mp.get_raw_output(tile))
 
         # actually process and save
-        write_mp.write(write_mp.get_raw_output(tile))
+        write_mp.write(tile, write_mp.get_raw_output(tile))
 
         # read written output
-        out_tile = readonly_mp.get_raw_output(tile)
-        assert not out_tile.data.mask.all()
+        assert not readonly_mp.get_raw_output(tile).mask.all()
     finally:
         shutil.rmtree(OUT_DIR, ignore_errors=True)
 
@@ -186,10 +178,9 @@ def test_get_raw_output_continue():
         assert mp.config.mode == "continue"
         tile = (5, 0, 0)
         # process and save
-        mp.write(mp.get_raw_output(tile))
+        mp.write(tile, mp.get_raw_output(tile))
         # read written data
-        out_tile = mp.get_raw_output(tile)
-        assert not out_tile.data.mask.all()
+        assert not mp.get_raw_output(tile).mask.all()
     finally:
         shutil.rmtree(OUT_DIR, ignore_errors=True)
 
@@ -219,21 +210,20 @@ def test_baselevels():
         mp.batch_process(quiet=True)
 
         # get tile from lower zoom level
-        for t in mp.get_process_tiles(4):
-            tile = mp.get_raw_output(t)
-            assert not tile.data.mask.all()
+        for tile in mp.get_process_tiles(4):
+            data = mp.get_raw_output(tile)
+            assert not data.mask.all()
             # write for next zoom level
-            mp.write(tile)
-            assert not mp.get_raw_output(tile.get_parent()).data.mask.all()
+            mp.write(tile, data)
+            assert not mp.get_raw_output(tile.get_parent()).mask.all()
 
         # get tile from higher zoom level
         tile = mp.get_process_tiles(6).next()
         # process and save
-        output = mp.get_raw_output(tile)
-        mp.write(output)
+        mp.write(tile, mp.get_raw_output(tile))
         # read from baselevel
         assert any([
-            not mp.get_raw_output(upper_tile).data.mask.all()
+            not mp.get_raw_output(upper_tile).mask.all()
             for upper_tile in tile.get_children()
         ])
     finally:
@@ -255,20 +245,17 @@ def test_baselevels_buffer():
         lower_tile = mp.get_process_tiles(4).next()
         # process and save
         for tile in lower_tile.get_children():
-            output = mp.get_raw_output(tile)
-            mp.write(output)
+            mp.write(tile, mp.get_raw_output(tile))
         # read from baselevel
-        out_tile = mp.get_raw_output(lower_tile)
-        assert not out_tile.data.mask.all()
+        assert not mp.get_raw_output(lower_tile).mask.all()
 
         # get tile from higher zoom level
         tile = mp.get_process_tiles(6).next()
         # process and save
-        output = mp.get_raw_output(tile)
-        mp.write(output)
+        mp.write(tile, mp.get_raw_output(tile))
         # read from baselevel
         assert any([
-            not mp.get_raw_output(upper_tile).data.mask.all()
+            not mp.get_raw_output(upper_tile).mask.all()
             for upper_tile in tile.get_children()
         ])
     finally:
@@ -292,17 +279,15 @@ def test_baselevels_buffer_antimeridian():
             # write data left and right of antimeridian
             west = mp.config.process_pyramid.tile(zoom, row, 0)
             shape = (3, ) + west.shape
-            west.data = np.ones(shape) * 0
-            mp.write(west)
+            mp.write(west, np.ones(shape) * 0)
             east = mp.config.process_pyramid.tile(
                 zoom, row, mp.config.process_pyramid.matrix_width(zoom) - 1
             )
-            east.data = np.ones(shape) * 10
-            mp.write(east)
+            mp.write(east, np.ones(shape) * 10)
             # use baselevel generation to interpolate tile and somehow
             # assert no data from across the antimeridian is read.
             lower_tile = mp.get_raw_output(west.get_parent())
-            assert np.where(lower_tile.data.data != 10, True, False).all()
+            assert np.where(lower_tile != 10, True, False).all()
     finally:
         shutil.rmtree(OUT_DIR, ignore_errors=True)
 
@@ -317,12 +302,11 @@ def test_processing():
             tiles = []
             for tile in mp.get_process_tiles(zoom):
                 output = mp.execute(tile)
-                tiles.append(output)
-                assert isinstance(output, BufferedTile)
-                assert isinstance(output.data, ma.MaskedArray)
-                assert output.data.shape == output.shape
-                assert not ma.all(output.data.mask)
-                mp.write(output)
+                tiles.append((tile, output))
+                assert isinstance(output, ma.MaskedArray)
+                assert output.shape == output.shape
+                assert not ma.all(output.mask)
+                mp.write(tile, output)
             mosaic, mosaic_affine = create_mosaic(tiles)
             try:
                 temp_vrt = os.path.join(OUT_DIR, str(zoom)+".vrt")
@@ -359,12 +343,11 @@ def test_processing_as_function():
             tiles = []
             for tile in mp.get_process_tiles(zoom):
                 output = mp.execute(tile)
-                tiles.append(output)
-                assert isinstance(output, BufferedTile)
-                assert isinstance(output.data, ma.MaskedArray)
-                assert output.data.shape == output.shape
-                assert not ma.all(output.data.mask)
-                mp.write(output)
+                tiles.append((tile, output))
+                assert isinstance(output, ma.MaskedArray)
+                assert output.shape == output.shape
+                assert not ma.all(output.mask)
+                mp.write(tile, output)
             mosaic, mosaic_affine = create_mosaic(tiles)
             try:
                 temp_vrt = os.path.join(OUT_DIR, str(zoom)+".vrt")
@@ -397,10 +380,10 @@ def test_multiprocessing():
     try:
         pool = Pool()
         for zoom in reversed(mp.config.zoom_levels):
-            for raw_output in pool.imap_unordered(
+            for tile, raw_output in pool.imap_unordered(
                 f, mp.get_process_tiles(zoom), chunksize=8
             ):
-                mp.write(raw_output)
+                mp.write(tile, raw_output)
     except KeyboardInterrupt:
         pool.terminate()
     finally:
@@ -411,7 +394,7 @@ def test_multiprocessing():
 
 def _worker(mp, tile):
     """Multiprocessing worker processing a tile."""
-    return mp.execute(tile)
+    return tile, mp.execute(tile)
 
 
 def test_write_empty():
@@ -419,7 +402,7 @@ def test_write_empty():
     mp = mapchete.open(
         os.path.join(SCRIPTDIR, "testdata/cleantopo_tl.mapchete"))
     # process and save
-    mp.write(mp.config.process_pyramid.tile(5, 0, 0))
+    mp.write(mp.config.process_pyramid.tile(5, 0, 0), None)
 
 
 def test_process_template():
@@ -478,16 +461,10 @@ def test_batch_process():
         os.path.join(SCRIPTDIR, "testdata/cleantopo_tl.mapchete"))
     try:
         # invalid parameters errors
-        try:
+        with pytest.raises(ValueError):
             mp.batch_process(zoom=1, tile=(1, 0, 0))
-            raise Exception()
-        except ValueError:
-            pass
-        try:
+        with pytest.raises(ValueError):
             mp.batch_process(debug=True, quiet=True)
-            raise Exception()
-        except ValueError:
-            pass
         # process single tile
         mp.batch_process(tile=(2, 0, 0))
         mp.batch_process(tile=(2, 0, 0), quiet=True)

--- a/test/test_mapchete.py
+++ b/test/test_mapchete.py
@@ -15,7 +15,6 @@ from multiprocessing import Pool
 from shapely.geometry import shape
 
 import mapchete
-from mapchete.tile import BufferedTile
 from mapchete.io.raster import create_mosaic
 from mapchete.errors import MapcheteProcessOutputError
 from mapchete import _batch


### PR DESCRIPTION
* better memory handling by detatching process output data from ``BufferedTile`` objects
* breaking API changes:
  * Mapchete.execute() returns raw data instead of tile with data attribute
  * Mapchete.read() returns raw data instead of tile with data attribute
  * Mapchete.get_raw_output() returns raw data instead of tile with data attribute
  * Mapchete.write() requires process_tile and data as arguments
  * same valid for all other read() and write() functions in drivers & MapcheteProcess object
* new MapcheteNodataTile exception to indicate an empty process output
