### PR TITLE
Snap bounds to zoom

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 ----
 * remove deprecated ``memoryfile`` usage for ``write_raster_window()``
 * fix ``s3`` path for ``mapchete index``
+* add ``snap_bounds``, ``clip_bounds`` functions & ``effective_bounds`` to config
 
 ----
 0.22

--- a/mapchete/__init__.py
+++ b/mapchete/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-from mapchete._core import open, count_tiles, Mapchete, MapcheteProcess
+from mapchete._core import (open, count_tiles, Mapchete, MapcheteProcess)
 
 
 __all__ = ['open', 'count_tiles', 'Mapchete', 'MapcheteProcess']

--- a/mapchete/_core.py
+++ b/mapchete/_core.py
@@ -15,6 +15,7 @@ import signal
 import six
 import threading
 from tilematrix import TilePyramid
+from tilematrix._funcs import Bounds
 import time
 from traceback import format_exc
 import types
@@ -23,7 +24,7 @@ from mapchete.commons import clip as commons_clip
 from mapchete.commons import contours as commons_contours
 from mapchete.commons import hillshade as commons_hillshade
 from mapchete.config import MapcheteConfig
-from mapchete.tile import BufferedTile
+from mapchete.tile import BufferedTile, BufferedTilePyramid
 from mapchete.io import raster
 from mapchete.errors import (
     MapcheteProcessException, MapcheteProcessOutputError, MapcheteNodataTile

--- a/mapchete/config.py
+++ b/mapchete/config.py
@@ -372,26 +372,29 @@ class MapcheteConfig(object):
         if "baselevels" not in self._raw:
             return {}
         baselevels = self._raw["baselevels"]
-        minmax = {
-            k: v for k, v in six.iteritems(baselevels) if k in ["min", "max"]}
+        minmax = {k: v for k, v in six.iteritems(baselevels) if k in ["min", "max"]}
         if not minmax:
-            raise MapcheteConfigError(
-                "no min and max values given for baselevels")
+            raise MapcheteConfigError("no min and max values given for baselevels")
         for v in minmax.values():
             if not isinstance(v, int) or v < 0:
                 raise MapcheteConfigError(
-                    "invalid baselevel zoom parameter given: %s" % (
-                        minmax.values()))
+                    "invalid baselevel zoom parameter given: %s" % minmax.values()
+                )
+        zooms = list(range(
+            minmax.get("min", min(self.zoom_levels)),
+            minmax.get("max", max(self.zoom_levels)) + 1)
+        )
+        if not set(self.zoom_levels).difference(set(zooms)):
+            raise MapcheteConfigError("baselevels zooms fully cover process zooms")
         return dict(
-            zooms=list(range(
-                minmax.get("min", min(self.zoom_levels)),
-                minmax.get("max", max(self.zoom_levels)) + 1)),
+            zooms=zooms,
             lower=baselevels.get("lower", "nearest"),
             higher=baselevels.get("higher", "nearest"),
             tile_pyramid=BufferedTilePyramid(
                 self.output_pyramid.grid,
                 pixelbuffer=self.output_pyramid.pixelbuffer,
-                metatiling=self.process_pyramid.metatiling))
+                metatiling=self.process_pyramid.metatiling)
+        )
 
     @cached_property
     def process_func(self):

--- a/mapchete/config.py
+++ b/mapchete/config.py
@@ -250,16 +250,14 @@ class MapcheteConfig(object):
         Process bounds sometimes have to be larger, because all intersecting process
         tiles have to be covered as well.
         """
-        if self.baselevels:
-            lowest_non_baselevel = min(
-                set(self.init_zoom_levels).difference(set(self.baselevels["zooms"]))
-            )
-        else:
-            lowest_non_baselevel = min(self.init_zoom_levels)
         return snap_bounds(
             bounds=clip_bounds(bounds=self.init_bounds, clip=self.process_pyramid.bounds),
             pyramid=self.process_pyramid,
-            zoom=lowest_non_baselevel
+            zoom=min(
+                self.baselevels["zooms"]
+            ) if self.baselevels else min(
+                self.init_zoom_levels
+            )
         )
 
     @cached_property

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 rasterio>=1.0a12
-tilematrix>=0.12
+tilematrix>=0.15
 fiona
 shapely
 pyyaml

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     package_dir={'static': 'static'},
     package_data={'mapchete.static': ['*']},
     install_requires=[
-        'tilematrix>=0.12',
+        'tilematrix>=0.15',
         'fiona',
         'pyyaml',
         'flask',

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -141,7 +141,7 @@ def test_effective_bounds(files_bounds, baselevels):
     )
     assert config.effective_bounds != config.init_bounds
     assert config.effective_bounds == snap_bounds(
-        bounds=config.init_bounds, pyramid=config.process_pyramid, zoom=7
+        bounds=config.init_bounds, pyramid=config.process_pyramid, zoom=5
     )
 
     with pytest.raises(MapcheteConfigError):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -144,6 +144,13 @@ def test_effective_bounds(files_bounds, baselevels):
         bounds=config.init_bounds, pyramid=config.process_pyramid, zoom=7
     )
 
+    with pytest.raises(MapcheteConfigError):
+        MapcheteConfig(dict(
+            baselevels.dict,
+            zoom_levels=dict(min=7, max=7),
+            baselevels=dict(lower="cubic", max=7)
+        ))
+
 
 def test_read_mapchete_input(mapchete_input):
     """Read Mapchete files as input files."""

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -8,7 +8,7 @@ from shapely.wkt import loads
 from copy import deepcopy
 
 import mapchete
-from mapchete.config import MapcheteConfig
+from mapchete.config import MapcheteConfig, snap_bounds
 from mapchete.errors import MapcheteDriverError, MapcheteConfigError
 
 
@@ -130,6 +130,21 @@ def test_bounds_from_input_files(files_bounds):
     assert config.area_at_zoom(10).equals(test_polygon)
 
 
+def test_effective_bounds(files_bounds, baselevels):
+    config = MapcheteConfig(files_bounds.dict)
+    assert config.effective_bounds == snap_bounds(
+        bounds=config.bounds, pyramid=config.process_pyramid, zoom=min(config.zoom_levels)
+    )
+
+    config = MapcheteConfig(
+        baselevels.dict, zoom=[5, 7], bounds=(0, 1, 2, 3)
+    )
+    assert config.effective_bounds != config.init_bounds
+    assert config.effective_bounds == snap_bounds(
+        bounds=config.init_bounds, pyramid=config.process_pyramid, zoom=7
+    )
+
+
 def test_read_mapchete_input(mapchete_input):
     """Read Mapchete files as input files."""
     config = MapcheteConfig(mapchete_input.path)
@@ -215,4 +230,4 @@ def test_abstract_input(abstract_input):
 
 def test_init_zoom(cleantopo_br):
     with mapchete.open(cleantopo_br.dict, zoom=[3, 5]) as mp:
-        assert mp.config.init_zoom_levels == range(3, 6)
+        assert mp.config.init_zoom_levels == list(range(3, 6))

--- a/test/test_deprecated.py
+++ b/test/test_deprecated.py
@@ -18,4 +18,4 @@ def test_parse_deprecated_zooms(deprecated_params):
     deprecated_params.dict.pop("process_zoom")
     deprecated_params.dict.update(process_minzoom=0, process_maxzoom=5)
     with mapchete.open(deprecated_params.dict) as mp:
-        assert mp.config.zoom_levels == range(0, 6)
+        assert mp.config.zoom_levels == list(range(0, 6))


### PR DESCRIPTION
Added `effective_bounds` to configuration which resizes bounds to tile grid. This is important for some input drivers which need to initialize with the real bounds (= including all process tiles).