### PR TITLE
enable VRT indexes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,15 @@ Changelog
 #########
 
 ----
+0.26
+----
+* enable VRT creation for indexes
+* added ``--vrt`` flag and ``--idx_out_dir`` option to ``mapchete execute``
+* renamed ``--out_dir`` to ``--idx_out_dir`` for ``mapchete index``
+* ``BufferedTile`` shape (``height``, ``width``) and bounds (``left``, ``bottom``, ``right`` and ``top``) properties now return correct values
+* ``BufferedTile.shape`` now follows the order ``(height, width)`` (update from ``tilematrix 0.18``)
+
+----
 0.25
 ----
 * use ``concurrent.futures`` instead of ``multiprocessing``

--- a/README.rst
+++ b/README.rst
@@ -153,6 +153,24 @@ don't install the binaries but build them on your system:
     pip install "rasterio>=1.0.2" "fiona>=1.8b1" --no-binary :all:
 
 
+To keep the core dependencies miimal if you install mapchete using ``pip``, some features
+are only available if you manually install additional dependencies:
+
+.. code-block:: shell
+
+    # for contour extraction:
+    pip install mapchete[contours]
+
+    # for S3 bucket reading and writing:
+    pip install mapchete[s3]
+
+    # for mapchete serve:
+    pip install mapchete[serve]
+
+    # for VRT generation:
+    pip install mapchete[vrt]
+
+
 -------
 License
 -------

--- a/mapchete/__init__.py
+++ b/mapchete/__init__.py
@@ -14,4 +14,4 @@ logging.getLogger("rasterio").setLevel(logging.ERROR)
 logging.getLogger("fiona").setLevel(logging.ERROR)
 
 
-__version__ = "0.25"
+__version__ = "0.26"

--- a/mapchete/cli/default/index.py
+++ b/mapchete/cli/default/index.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 @utils.opt_geojson
 @utils.opt_gpkg
 @utils.opt_shp
+@utils.opt_vrt
 @utils.opt_txt
 @utils.opt_fieldname
 @utils.opt_basepath
@@ -45,6 +46,7 @@ def index(
     geojson=False,
     gpkg=False,
     shp=False,
+    vrt=False,
     txt=False,
     fieldname=None,
     basepath=None,
@@ -57,9 +59,10 @@ def index(
     debug=False,
     logfile=None
 ):
-    if not any([geojson, gpkg, shp, txt]):
+    if not any([geojson, gpkg, shp, txt, vrt]):
         raise click.MissingParameter(
-            "At least one of '--geojson', '--gpkg', '--shp', or '--txt' must be provided.",
+            """At least one of '--geojson', '--gpkg', '--shp', '--vrt' or '--txt'"""
+            """must be provided.""",
             param_type="option"
         )
 
@@ -91,6 +94,7 @@ def index(
                             geojson=geojson,
                             gpkg=gpkg,
                             shapefile=shp,
+                            vrt=vrt,
                             txt=txt,
                             fieldname=fieldname,
                             basepath=basepath,
@@ -122,6 +126,7 @@ def index(
                                 geojson=geojson,
                                 gpkg=gpkg,
                                 shapefile=shp,
+                                vrt=vrt,
                                 txt=txt,
                                 fieldname=fieldname,
                                 basepath=basepath,

--- a/mapchete/cli/default/index.py
+++ b/mapchete/cli/default/index.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 @click.command(help="Create index of output tiles.")
 @utils.arg_mapchete_files
-@utils.opt_out_dir
+@utils.opt_idx_out_dir
 @utils.opt_geojson
 @utils.opt_gpkg
 @utils.opt_shp
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 @utils.opt_logfile
 def index(
     mapchete_files,
-    out_dir=None,
+    idx_out_dir=None,
     geojson=False,
     gpkg=False,
     shp=False,
@@ -90,7 +90,7 @@ def index(
                         zoom_index_gen(
                             mp=mp,
                             zoom=tile.zoom,
-                            out_dir=out_dir if out_dir else mp.config.output.path,
+                            out_dir=idx_out_dir if idx_out_dir else mp.config.output.path,
                             geojson=geojson,
                             gpkg=gpkg,
                             shapefile=shp,
@@ -98,7 +98,8 @@ def index(
                             txt=txt,
                             fieldname=fieldname,
                             basepath=basepath,
-                            for_gdal=for_gdal),
+                            for_gdal=for_gdal
+                        ),
                         total=mp.count_tiles(tile.zoom, tile.zoom),
                         unit="tile",
                         disable=debug
@@ -122,7 +123,9 @@ def index(
                             zoom_index_gen(
                                 mp=mp,
                                 zoom=z,
-                                out_dir=out_dir if out_dir else mp.config.output.path,
+                                out_dir=(
+                                    idx_out_dir if idx_out_dir else mp.config.output.path
+                                ),
                                 geojson=geojson,
                                 gpkg=gpkg,
                                 shapefile=shp,

--- a/mapchete/cli/utils.py
+++ b/mapchete/cli/utils.py
@@ -78,8 +78,8 @@ opt_out_path = click.option(
     "--out_path", "-op", type=click.Path(), default=os.path.join(os.getcwd(), "output"),
     help="Process output path."
 )
-opt_out_dir = click.option(
-    "--out_dir", "-od", type=click.Path(),
+opt_idx_out_dir = click.option(
+    "--idx_out_dir", "-od", type=click.Path(),
     help="Index output directory."
 )
 opt_input_file = click.option(

--- a/mapchete/cli/utils.py
+++ b/mapchete/cli/utils.py
@@ -161,6 +161,10 @@ opt_shp = click.option(
     "--shp", is_flag=True,
     help="Write Shapefile index."
 )
+opt_vrt = click.option(
+    "--vrt", is_flag=True,
+    help="Write VRT file."
+)
 opt_txt = click.option(
     "--txt", is_flag=True,
     help="Write output tile paths to text file."

--- a/mapchete/index.py
+++ b/mapchete/index.py
@@ -198,7 +198,7 @@ def _tile_path(orig_path, basepath, for_gdal):
 
 
 class VectorFileWriter():
-    """Base class for GeoJSONWriter and GeoPackageWriter."""
+    """Writes GeoJSON or GeoPackage files."""
 
     def __init__(
         self, out_path=None, crs=None, fieldname=None, driver=None

--- a/mapchete/index.py
+++ b/mapchete/index.py
@@ -19,7 +19,6 @@ from contextlib import ExitStack
 from copy import deepcopy
 import fiona
 import logging
-from lxml.builder import ElementMaker
 import operator
 import os
 from shapely.geometry import mapping
@@ -336,6 +335,8 @@ class TextFileWriter():
 class VRTFileWriter():
     """Generates GDAL-style VRT file."""
     def __init__(self, out_path=None, output=None, out_pyramid=None):
+        # see if lxml is installed before checking all output tiles
+        from lxml.builder import ElementMaker
         self.path = out_path
         self._tp = out_pyramid
         self._output = output
@@ -398,6 +399,8 @@ class VRTFileWriter():
         return exists
 
     def close(self):
+        from lxml.builder import ElementMaker
+
         logger.debug("%s new entries in %s", self.new_entries, self)
         if not self._new:
             logger.debug("no entries to write")

--- a/mapchete/index.py
+++ b/mapchete/index.py
@@ -8,6 +8,10 @@ Available index types:
 - textfile with tiles list
     If process output is online (e.g. a public endpoint of an S3 container),
     this file can be passed on to wget to download all process output.
+- VRT
+    Virtual raster dataset format by GDAL. This enables GIS tools to read multiple
+    files at once, e.g. QGIS can open a zoom VRT so the user doesn't have to open
+    all GeoTIFF files from a certain zoom level.
 
 All index types are generated once per zoom level. For example GeoPackage will
 generate GPKG files 3.gpkg, 4.gpkg and 5.gpkg for zoom levels 3, 4 and 5.
@@ -375,8 +379,6 @@ class VRTFileWriter():
         return self._tp.tile(*map(int, os.path.splitext(path)[0].split("/")[-3:]))
 
     def _add_entry(self, tile=None, path=None):
-        if tile is None:
-            tile = self._path_to_tile(path)
         self._new[tile] = path
 
     def _xml_to_entries(self, xml_string):

--- a/mapchete/io/__init__.py
+++ b/mapchete/io/__init__.py
@@ -174,7 +174,7 @@ def write_output_metadata(output_params):
             current_params = params_to_dump(output_params)
             grid = existing_params["pyramid"]["grid"]
             if grid["type"] == "geodetic" and grid["shape"] == [2, 1]:
-                raise MapcheteConfigError(
+                raise DeprecationWarning(
                     """Deprecated grid shape ordering found. """
                     """Please change grid shape from [2, 1] to [1, 2] in %s."""
                     % metadata_path

--- a/mapchete/io/__init__.py
+++ b/mapchete/io/__init__.py
@@ -152,6 +152,13 @@ def absolute_path(path=None, base_dir=None):
             return os.path.abspath(os.path.join(base_dir, path))
 
 
+def relative_path(path=None, base_dir=None):
+    if os.path.isabs(path):
+        return os.path.relpath(path, base_dir)
+    else:
+        return path
+
+
 def makedirs(path):
     """Create all subdirectories of path if path is local."""
     if not path_is_remote(path):

--- a/mapchete/io/__init__.py
+++ b/mapchete/io/__init__.py
@@ -140,7 +140,18 @@ def path_exists(path):
 
 
 def absolute_path(path=None, base_dir=None):
-    """Return absolute path if local."""
+    """
+    Return absolute path if path is local.
+
+    Parameters:
+    -----------
+    path : path to file
+    base_dir : base directory used for absolute path
+
+    Returns:
+    --------
+    absolute path
+    """
     if path_is_remote(path):
         return path
     else:
@@ -153,6 +164,18 @@ def absolute_path(path=None, base_dir=None):
 
 
 def relative_path(path=None, base_dir=None):
+    """
+    Return relative path if path is local.
+
+    Parameters:
+    -----------
+    path : path to file
+    base_dir : directory where path sould be relative to
+
+    Returns:
+    --------
+    relative path
+    """
     if path_is_remote(path) or not os.path.isabs(path):
         return path
     else:
@@ -160,7 +183,13 @@ def relative_path(path=None, base_dir=None):
 
 
 def makedirs(path):
-    """Create all subdirectories of path if path is local."""
+    """
+    Silently create all subdirectories of path if path is local.
+
+    Parameters:
+    -----------
+    path : path
+    """
     if not path_is_remote(path):
         try:
             os.makedirs(path)

--- a/mapchete/io/__init__.py
+++ b/mapchete/io/__init__.py
@@ -100,9 +100,9 @@ def path_is_remote(path, s3=True):
     -------
     is_remote : bool
     """
-    prefixes = ("http://", "https://")
+    prefixes = ("http://", "https://", "/vsicurl/")
     if s3:
-        prefixes += ("s3://", )
+        prefixes += ("s3://", "/vsis3/")
     return path.startswith(prefixes)
 
 
@@ -153,10 +153,10 @@ def absolute_path(path=None, base_dir=None):
 
 
 def relative_path(path=None, base_dir=None):
-    if os.path.isabs(path):
-        return os.path.relpath(path, base_dir)
-    else:
+    if path_is_remote(path) or not os.path.isabs(path):
         return path
+    else:
+        return os.path.relpath(path, base_dir)
 
 
 def makedirs(path):

--- a/mapchete/io/__init__.py
+++ b/mapchete/io/__init__.py
@@ -172,6 +172,13 @@ def write_output_metadata(output_params):
             logger.debug("%s exists", metadata_path)
             logger.debug("existing output parameters: %s", existing_params)
             current_params = params_to_dump(output_params)
+            grid = existing_params["pyramid"]["grid"]
+            if grid["type"] == "geodetic" and grid["shape"] == [2, 1]:
+                raise MapcheteConfigError(
+                    """Deprecated grid shape ordering found. """
+                    """Please change grid shape from [2, 1] to [1, 2] in %s."""
+                    % metadata_path
+                )
             if (
                 existing_params["pyramid"] != current_params["pyramid"] or
                 existing_params["driver"]["format"] != current_params["driver"]["format"]

--- a/mapchete/io/raster.py
+++ b/mapchete/io/raster.py
@@ -510,7 +510,7 @@ def bounds_to_ranges(out_bounds=None, in_affine=None, in_shape=None):
     )
 
 
-def tiles_to_affine_shape(tiles, clip_to_pyramid_bounds=False):
+def tiles_to_affine_shape(tiles):
     """
     Return Affine and shape of combined tiles.
 
@@ -532,30 +532,12 @@ def tiles_to_affine_shape(tiles, clip_to_pyramid_bounds=False):
         max([t.right for t in tiles]),
         max([t.top for t in tiles]),
     )
-    if clip_to_pyramid_bounds:
-        tp = tiles[0].tp
-        left = max([left, tp.left])
-        bottom = max([bottom, tp.bottom])
-        right = min([right, tp.right])
-        top = min([top, tp.top])
     return (
         Affine(pixel_size, 0, left, 0, -pixel_size, top),
         Shape(
             width=int(round((right - left) / pixel_size, 0)),
             height=int(round((top - bottom) / pixel_size, 0)),
         )
-    )
-
-
-def affine_shape_to_bounds(affine=None, shape=None):
-    logger.debug(affine)
-    pixel_x_size, _, left, _, pixel_y_size, top = affine[:6]
-    height, width = shape
-    return Bounds(
-        left=left,
-        bottom=top + (height * pixel_y_size),
-        right=left + (width * pixel_x_size),
-        top=top
     )
 
 

--- a/mapchete/tile.py
+++ b/mapchete/tile.py
@@ -168,6 +168,10 @@ class BufferedTile(Tile):
         Tile.__init__(self, tile.tile_pyramid, tile.zoom, tile.row, tile.col)
         self._tile = tile
         self.pixelbuffer = pixelbuffer
+        self.left = self.bounds.left
+        self.bottom = self.bounds.bottom
+        self.right = self.bounds.right
+        self.top = self.bounds.top
 
     @cached_property
     def profile(self):
@@ -177,22 +181,23 @@ class BufferedTile(Tile):
             width=self.width,
             height=self.height,
             transform=None,
-            affine=self.affine)
+            affine=self.affine
+        )
 
     @cached_property
     def height(self):
         """Return buffered height."""
-        return self._tile.shape(pixelbuffer=self.pixelbuffer)[0]
+        return self._tile.shape(pixelbuffer=self.pixelbuffer).height
 
     @cached_property
     def width(self):
         """Return buffered width."""
-        return self._tile.shape(pixelbuffer=self.pixelbuffer)[1]
+        return self._tile.shape(pixelbuffer=self.pixelbuffer).width
 
     @cached_property
     def shape(self):
         """Return buffered shape."""
-        return (self.height, self.width)
+        return self._tile.shape(pixelbuffer=self.pixelbuffer)
 
     @cached_property
     def affine(self):
@@ -218,9 +223,7 @@ class BufferedTile(Tile):
         children : list
             a list of ``BufferedTiles``
         """
-        return [
-            BufferedTile(tile, self.pixelbuffer)
-            for tile in self._tile.get_children()]
+        return [BufferedTile(t, self.pixelbuffer) for t in self._tile.get_children()]
 
     def get_parent(self):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ click-plugins
 click-spinner
 fiona>=1.8b1
 flask
+lxml
 matplotlib
 numpy
 pyproj

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ pyproj
 pyyaml
 rasterio>=1.0.2
 shapely
-tilematrix>=0.17
+tilematrix>=0.18
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ setup(
         'click-plugins',
         'click-spinner',
         'fiona>=1.8b1',
-        'lxml',
         'pyproj',
         'pyyaml',
         'rasterio>=1.0.2',
@@ -83,7 +82,8 @@ setup(
     extras_require={
         'contours': ['matplotlib'],
         's3': ['boto3'],
-        'serve': ['flask']
+        'serve': ['flask'],
+        'vrt': ['lxml']
     },
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
         'click-plugins',
         'click-spinner',
         'fiona>=1.8b1',
+        'lxml',
         'pyproj',
         'pyyaml',
         'rasterio>=1.0.2',

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         'pyproj',
         'pyyaml',
         'rasterio>=1.0.2',
-        'tilematrix>=0.17',
+        'tilematrix>=0.18',
         'tqdm'
     ] if not on_rtd else [],
     extras_require={

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -156,7 +156,7 @@ def test_execute_vrt(mp_tmpdir, cleantopo_br):
 
     # run with single tile
     run_cli(
-        ['execute', cleantopo_br.path, "-t", "5", "0", "0", "--vrt"]
+        ['execute', cleantopo_br.path, "-t", "5", "3", "7", "--vrt"]
     )
 
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -154,6 +154,11 @@ def test_execute_vrt(mp_tmpdir, cleantopo_br):
         with rasterio.open(vrt_path) as src:
             assert src.read().any()
 
+    # run with single tile
+    run_cli(
+        ['execute', cleantopo_br.path, "-t", "5", "0", "0", "--vrt"]
+    )
+
 
 def test_execute_verbose(mp_tmpdir, example_mapchete):
     """Using verbose output."""

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -159,6 +159,11 @@ def test_execute_vrt(mp_tmpdir, cleantopo_br):
         ['execute', cleantopo_br.path, "-t", "5", "3", "7", "--vrt"]
     )
 
+    # no new entries
+    run_cli(
+        ['execute', cleantopo_br.path, "-t", "5", "0", "0", "--vrt"]
+    )
+
 
 def test_execute_verbose(mp_tmpdir, example_mapchete):
     """Using verbose output."""

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -137,6 +137,24 @@ def test_execute_debug(mp_tmpdir, example_mapchete):
     )
 
 
+def test_execute_vrt(mp_tmpdir, cleantopo_br):
+    """Using debug output."""
+    run_cli(['execute', cleantopo_br.path, "-z", "5", "--vrt"])
+    with mapchete.open(cleantopo_br.dict) as mp:
+        vrt_path = os.path.join(mp.config.output.path, "5.vrt")
+        with rasterio.open(vrt_path) as src:
+            assert src.read().any()
+
+    # run again, this time with custom output directory
+    run_cli(
+        ['execute', cleantopo_br.path, "-z", "5", "--vrt", "--idx_out_dir", mp_tmpdir]
+    )
+    with mapchete.open(cleantopo_br.dict) as mp:
+        vrt_path = os.path.join(mp_tmpdir, "5.vrt")
+        with rasterio.open(vrt_path) as src:
+            assert src.read().any()
+
+
 def test_execute_verbose(mp_tmpdir, example_mapchete):
     """Using verbose output."""
     run_cli(['execute', example_mapchete.path, "-t", "10", "500", "1040", "--verbose"])


### PR DESCRIPTION
* enable VRT creation for indexes
* added ``--vrt`` flag and ``--idx_out_dir`` option to ``mapchete execute``
* renamed ``--out_dir`` to ``--idx_out_dir`` for ``mapchete index``
* ``BufferedTile`` shape (``height``, ``width``) and bounds (``left``, ``bottom``, ``right`` and ``top``) properties now return correct values
* ``BufferedTile.shape`` now follows the order ``(height, width)`` (update from ``tilematrix 0.18``)

closing #110 