### PR TITLE
Tiledata dir reproject

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,13 @@ Changelog
 #########
 
 ----
+0.27
+----
+* enable reading from output tile directories which have a different CRS
+* enable GeoPackage as single file input
+* fixed antimeridian shift check
+
+----
 0.26
 ----
 * enable VRT creation for indexes

--- a/mapchete/__init__.py
+++ b/mapchete/__init__.py
@@ -14,4 +14,4 @@ logging.getLogger("rasterio").setLevel(logging.ERROR)
 logging.getLogger("fiona").setLevel(logging.ERROR)
 
 
-__version__ = "0.26"
+__version__ = "0.27"

--- a/mapchete/formats/default/tile_directory.py
+++ b/mapchete/formats/default/tile_directory.py
@@ -5,7 +5,6 @@ import logging
 import numpy as np
 import numpy.ma as ma
 import os
-from rasterio.warp import calculate_default_transform
 from shapely.geometry import box, shape, mapping
 
 from mapchete.config import validate_values
@@ -144,49 +143,64 @@ class InputData(base.InputData):
         else:
             self._profile = None
 
-    def open(self, tile, **kwargs):
+    def open(
+        self,
+        tile,
+        fixed_zoom=None,
+        zoom_matching_method="gdal",
+        max_zoom=None,
+        fallback_to_higher_zoom=False,
+        **kwargs
+    ):
         """
         Return InputTile object.
 
         Parameters
         ----------
         tile : ``Tile``
+        fixed_zoom : None
+            If set, data will be read from exactly this zoom level
+        zoom_matching_method : str ('gdal' or 'min') (default: 'gdal')
+            gdal: Uses GDAL's standard method. Here, the target resolution is calculated
+                by averaging the extent's pixel sizes over both x and y axes. This
+                approach returns a zoom level which may not have the best quality but will
+                speed up reading significantly.
+            min: Returns the zoom level which matches the minimum resolution of the
+                extents four corner pixels. This approach returns the zoom level with the
+                best possible quality but with low performance. If the tile extent is
+                outside of the destination pyramid, a TopologicalError will be raised.
+        max_zoom : int (default: None)
+            If set, it will prevent reading from zoom levels above the maximum.
+        fallback_to_higher_zoom : bool (default: False)
+            In case no data is found at zoom level, try to read data from higher zoom
+            levels. Enabling this setting can lead to many IO requests in areas with no
+            data.
 
         Returns
         -------
         input tile : ``InputTile``
             tile view of input data
         """
-        if self.td_pyramid.crs == tile.tp.crs:
-            return InputTile(
-                tile,
-                tiles_paths=_get_tiles_paths(
-                    basepath=self.path,
-                    ext=self._ext,
-                    pyramid=self.td_pyramid,
-                    bounds=tile.bounds,
-                    zoom=tile.zoom
-                ),
-                file_type=self._file_type,
-                profile=self._profile,
-                td_crs=self.td_pyramid.crs,
-                **kwargs
-            )
+        # determine tile bounds in TileDirectory CRS
+        td_bounds = reproject_geometry(
+            tile.bbox,
+            src_crs=tile.tp.crs,
+            dst_crs=self.td_pyramid.crs
+        ).bounds
+
+        # find target zoom level
+        if fixed_zoom is not None:
+            zoom = fixed_zoom
         else:
-            # determine tile bounds in TileDirectory CRS
-            logger.debug("tile bounds: %s", tile.bounds)
-            td_bounds = reproject_geometry(
-                tile.bbox,
-                src_crs=tile.tp.crs,
-                dst_crs=self.td_pyramid.crs
-            ).bounds
-            logger.debug("converted tile bounds in TileDirectory CRS: %s", td_bounds)
+            zoom = tile_to_zoom_level(
+                tile, dst_pyramid=self.td_pyramid, method=zoom_matching_method
+            )
+            if max_zoom is not None:
+                zoom = min([zoom, max_zoom])
 
-            # get best target zoom level
-            zoom = tile_to_zoom_level(tile, dst_pyramid=self.td_pyramid)
-
-            # check if tiles exist and pass on to InputTile
+        if fallback_to_higher_zoom:
             tiles_paths = []
+            # check if tiles exist otherwise try higher zoom level
             while len(tiles_paths) == 0 and zoom >= 0:
                 tiles_paths = _get_tiles_paths(
                     basepath=self.path,
@@ -197,14 +211,22 @@ class InputData(base.InputData):
                 )
                 logger.debug("%s existing tiles found at zoom %s", len(tiles_paths), zoom)
                 zoom -= 1
-            return InputTile(
-                tile,
-                tiles_paths=tiles_paths,
-                file_type=self._file_type,
-                profile=self._profile,
-                td_crs=self.td_pyramid.crs,
-                **kwargs
+        else:
+            tiles_paths = _get_tiles_paths(
+                basepath=self.path,
+                ext=self._ext,
+                pyramid=self.td_pyramid,
+                bounds=td_bounds,
+                zoom=zoom
             )
+        return InputTile(
+            tile,
+            tiles_paths=tiles_paths,
+            file_type=self._file_type,
+            profile=self._profile,
+            td_crs=self.td_pyramid.crs,
+            **kwargs
+        )
 
     def bbox(self, out_crs=None):
         """
@@ -330,28 +352,14 @@ class InputTile(base.InputTile):
                     mask=True
                 )
             else:
-                return resample_from_array(
-                    in_raster=create_mosaic(
-                        tiles=[
-                            (
-                                _tile,
-                                read_raster_window(
-                                    _path,
-                                    _tile,
-                                    indexes=indexes,
-                                    resampling=resampling,
-                                    src_nodata=self._profile["nodata"],
-                                    dst_nodata=dst_nodata,
-                                    gdal_opts=gdal_opts
-                                )
-                            )
-                            for _tile, _path in self._tiles_paths
-                        ],
-                        nodata=self._profile["nodata"]
-                    ),
-                    out_tile=self.tile,
+                return read_raster_window(
+                    [path for _, path in self._tiles_paths],
+                    self.tile,
+                    indexes=indexes,
                     resampling=resampling,
-                    nodataval=self._profile["nodata"]
+                    src_nodata=self._profile["nodata"],
+                    dst_nodata=dst_nodata,
+                    gdal_opts=gdal_opts
                 )
 
     def is_empty(self):

--- a/mapchete/formats/default/tile_directory.py
+++ b/mapchete/formats/default/tile_directory.py
@@ -324,22 +324,11 @@ class InputTile(base.InputTile):
             if self.is_empty():
                 return []
             else:
-                return [
-                    {
-                        "properties": g["properties"],
-                        "geometry": mapping(
-                            reproject_geometry(
-                                shape(g["geometry"]),
-                                src_crs=self._td_crs,
-                                dst_crs=self.tile.tp.crs
-                            )
-                        )
-                    }
-                    for g in chain.from_iterable([
-                        read_vector_window(p, self.tile, validity_check=validity_check)
-                        for _, p in self._tiles_paths
-                    ])
-                ]
+                return read_vector_window(
+                    [path for _, path in self._tiles_paths],
+                    self.tile,
+                    validity_check=validity_check
+                )
         else:
             if self.is_empty():
                 bands = len(indexes) if indexes else self._profile["count"]

--- a/mapchete/formats/default/tile_directory.py
+++ b/mapchete/formats/default/tile_directory.py
@@ -146,9 +146,10 @@ class InputData(base.InputData):
     def open(
         self,
         tile,
-        fixed_zoom=None,
-        zoom_matching_method="gdal",
-        max_zoom=None,
+        tile_directory_zoom=None,
+        matching_method="gdal",
+        matching_max_zoom=None,
+        matching_precision=8,
         fallback_to_higher_zoom=False,
         **kwargs
     ):
@@ -158,9 +159,9 @@ class InputData(base.InputData):
         Parameters
         ----------
         tile : ``Tile``
-        fixed_zoom : None
+        tile_directory_zoom : None
             If set, data will be read from exactly this zoom level
-        zoom_matching_method : str ('gdal' or 'min') (default: 'gdal')
+        matching_method : str ('gdal' or 'min') (default: 'gdal')
             gdal: Uses GDAL's standard method. Here, the target resolution is calculated
                 by averaging the extent's pixel sizes over both x and y axes. This
                 approach returns a zoom level which may not have the best quality but will
@@ -169,8 +170,10 @@ class InputData(base.InputData):
                 extents four corner pixels. This approach returns the zoom level with the
                 best possible quality but with low performance. If the tile extent is
                 outside of the destination pyramid, a TopologicalError will be raised.
-        max_zoom : int (default: None)
+        matching_max_zoom : int (default: None)
             If set, it will prevent reading from zoom levels above the maximum.
+        matching_precision : int
+            Round resolutions to n digits before comparing.
         fallback_to_higher_zoom : bool (default: False)
             In case no data is found at zoom level, try to read data from higher zoom
             levels. Enabling this setting can lead to many IO requests in areas with no
@@ -189,14 +192,15 @@ class InputData(base.InputData):
         ).bounds
 
         # find target zoom level
-        if fixed_zoom is not None:
-            zoom = fixed_zoom
+        if tile_directory_zoom is not None:
+            zoom = tile_directory_zoom
         else:
             zoom = tile_to_zoom_level(
-                tile, dst_pyramid=self.td_pyramid, method=zoom_matching_method
+                tile, dst_pyramid=self.td_pyramid, matching_method=matching_method,
+                precision=matching_precision
             )
-            if max_zoom is not None:
-                zoom = min([zoom, max_zoom])
+            if matching_max_zoom is not None:
+                zoom = min([zoom, matching_max_zoom])
 
         if fallback_to_higher_zoom:
             tiles_paths = []
@@ -219,6 +223,7 @@ class InputData(base.InputData):
                 bounds=td_bounds,
                 zoom=zoom
             )
+            logger.debug("%s existing tiles found at zoom %s", len(tiles_paths), zoom)
         return InputTile(
             tile,
             tiles_paths=tiles_paths,

--- a/mapchete/io/__init__.py
+++ b/mapchete/io/__init__.py
@@ -168,7 +168,6 @@ def tile_to_zoom_level(tile, dst_pyramid=None, matching_method="gdal", precision
         zoom = 0
         while True:
             td_resolution = round(dst_pyramid.pixel_x_size(zoom), precision)
-            logger.debug("td_resolution: %s", td_resolution)
             if td_resolution <= tile_resolution:
                 break
             zoom += 1

--- a/mapchete/io/__init__.py
+++ b/mapchete/io/__init__.py
@@ -90,7 +90,7 @@ def get_segmentize_value(input_file=None, tile_pyramid=None):
     return pixelsize * tile_pyramid.tile_size
 
 
-def tile_to_zoom_level(tile, dst_pyramid=None, method="gdal", precision=8):
+def tile_to_zoom_level(tile, dst_pyramid=None, matching_method="gdal", precision=8):
     """
     Determine the best zoom level in target TilePyramid from given Tile.
 
@@ -99,7 +99,7 @@ def tile_to_zoom_level(tile, dst_pyramid=None, method="gdal", precision=8):
     ----------
     tile : BufferedTile
     dst_pyramid : BufferedTilePyramid
-    method : str ('gdal' or 'min')
+    matching_method : str ('gdal' or 'min')
         gdal: Uses GDAL's standard method. Here, the target resolution is calculated by
             averaging the extent's pixel sizes over both x and y axes. This approach
             returns a zoom level which may not have the best quality but will speed up
@@ -127,7 +127,7 @@ def tile_to_zoom_level(tile, dst_pyramid=None, method="gdal", precision=8):
     if tile.tp.crs == dst_pyramid.crs:
         return tile.zoom
     else:
-        if method == "gdal":
+        if matching_method == "gdal":
             # use rasterio/GDAL method to calculate default warp target properties
             transform, width, height = calculate_default_transform(
                 tile.tp.crs,
@@ -138,7 +138,7 @@ def tile_to_zoom_level(tile, dst_pyramid=None, method="gdal", precision=8):
             )
             # this is the resolution the tile would have in destination TilePyramid CRS
             tile_resolution = round(transform[0], precision)
-        elif method == "min":
+        elif matching_method == "min":
             # calculate the minimum pixel size from the four tile corner pixels
             l, b, r, t = tile.bounds
             x = tile.pixel_x_size
@@ -160,7 +160,7 @@ def tile_to_zoom_level(tile, dst_pyramid=None, method="gdal", precision=8):
             else:
                 raise TopologicalError("tile outside of destination pyramid")
         else:
-            raise ValueError("invalid method given: %s", method)
+            raise ValueError("invalid method given: %s", matching_method)
         logger.debug(
             "we are looking for a zoom level interpolating to %s resolution",
             tile_resolution

--- a/mapchete/io/__init__.py
+++ b/mapchete/io/__init__.py
@@ -95,6 +95,23 @@ def tile_to_zoom_level(tile, dst_pyramid=None, method="gdal"):
     Determine the best zoom level in target TilePyramid from given Tile.
 
 
+    Parameters
+    ----------
+    tile : BufferedTile
+    dst_pyramid : BufferedTilePyramid
+    method : str ('gdal' or 'min')
+        gdal: Uses GDAL's standard method. Here, the target resolution is calculated by
+            averaging the extent's pixel sizes over both x and y axes. This approach
+            returns a zoom level which may not have the best quality but will speed up
+            reading significantly.
+        min: Returns the zoom level which matches the minimum resolution of the extent's
+            four corner pixels. This approach returns the zoom level with the best
+            possible quality but with low performance. If the tile extent is outside of
+            the destination pyramid, a TopologicalError will be raised.
+
+    Returns
+    -------
+    zoom : int
     """
     def width_height(bounds):
         try:

--- a/mapchete/io/__init__.py
+++ b/mapchete/io/__init__.py
@@ -135,24 +135,24 @@ def tile_to_zoom_level(tile, dst_pyramid=None, method="gdal"):
                     w, h = width_height(bounds)
                     res.extend([w, h])
                 except TopologicalError:
-                    print("pixel outside of destination pyramid")
-            if not res:
+                    logger.debug("pixel outside of destination pyramid")
+            if res:
+                tile_resolution = min(res)
+            else:
                 raise TopologicalError("tile outside of destination pyramid")
-            tile_resolution = min(res)
         else:
             raise ValueError("invalid method given: %s", method)
         logger.debug(
             "we are looking for a zoom level interpolating to %s resolution",
             tile_resolution
         )
-        print("looking for %s" % tile_resolution)
         zoom = 0
         while True:
             td_resolution = dst_pyramid.pixel_x_size(zoom)
             if td_resolution <= tile_resolution:
                 break
             zoom += 1
-        logger.debug("target zoom: %s (%s)", zoom, td_resolution)
+        logger.debug("target zoom for %s: %s (%s)", tile_resolution, zoom, td_resolution)
         return zoom
 
 

--- a/mapchete/io/__init__.py
+++ b/mapchete/io/__init__.py
@@ -4,6 +4,8 @@ import json
 import logging
 import os
 import rasterio
+from rasterio.warp import calculate_default_transform
+from shapely.errors import TopologicalError
 from shapely.geometry import box
 from tilematrix import TilePyramid
 from urllib.request import urlopen
@@ -33,8 +35,7 @@ def get_best_zoom_level(input_file, tile_pyramid_type):
     Parameters
     ----------
     input_file : path to raster file
-    tile_pyramid_type : ``TilePyramid`` projection (``geodetic`` or
-        ``mercator``)
+    tile_pyramid_type : ``TilePyramid`` projection (``geodetic`` or``mercator``)
 
     Returns
     -------
@@ -87,6 +88,72 @@ def get_segmentize_value(input_file=None, tile_pyramid=None):
     with rasterio.open(input_file, "r") as input_raster:
         pixelsize = input_raster.transform[0]
     return pixelsize * tile_pyramid.tile_size
+
+
+def tile_to_zoom_level(tile, dst_pyramid=None, method="gdal"):
+    """
+    Determine the best zoom level in target TilePyramid from given Tile.
+
+
+    """
+    def width_height(bounds):
+        try:
+            l, b, r, t = reproject_geometry(
+                box(*bounds), src_crs=tile.crs, dst_crs=dst_pyramid.crs
+            ).bounds
+        except ValueError:
+            raise TopologicalError("bounds cannot be translated into target CRS")
+        return r - l, t - b
+
+    if tile.tp.crs == dst_pyramid.crs:
+        return tile.zoom
+    else:
+        if method == "gdal":
+            # use rasterio/GDAL method to calculate default warp target properties
+            transform, width, height = calculate_default_transform(
+                tile.tp.crs,
+                dst_pyramid.crs,
+                tile.width,
+                tile.height,
+                *tile.bounds
+            )
+            # this is the resolution the tile would have in destination TilePyramid CRS
+            tile_resolution = transform[0]
+        elif method == "min":
+            # calculate the minimum pixel size from the four tile corner pixels
+            l, b, r, t = tile.bounds
+            x = tile.pixel_x_size
+            y = tile.pixel_y_size
+            res = []
+            for bounds in [
+                (l, t - y, l + x, t),  # left top
+                (l, b, l + x, b + y),  # left bottom
+                (r - x, b, r, b + y),  # right bottom
+                (r - x, t - y, r, t)   # right top
+            ]:
+                try:
+                    w, h = width_height(bounds)
+                    res.extend([w, h])
+                except TopologicalError:
+                    print("pixel outside of destination pyramid")
+            if not res:
+                raise TopologicalError("tile outside of destination pyramid")
+            tile_resolution = min(res)
+        else:
+            raise ValueError("invalid method given: %s", method)
+        logger.debug(
+            "we are looking for a zoom level interpolating to %s resolution",
+            tile_resolution
+        )
+        print("looking for %s" % tile_resolution)
+        zoom = 0
+        while True:
+            td_resolution = dst_pyramid.pixel_x_size(zoom)
+            if td_resolution <= tile_resolution:
+                break
+            zoom += 1
+        logger.debug("target zoom: %s (%s)", zoom, td_resolution)
+        return zoom
 
 
 def path_is_remote(path, s3=True):

--- a/mapchete/io/raster.py
+++ b/mapchete/io/raster.py
@@ -109,10 +109,10 @@ def _read_raster_window(
                 src_nodata=src_nodata,
                 dst_nodata=dst_nodata
             )
-            dst_array = np.where(f_array.mask, dst_array, f_array).astype(dst_array.dtype)
-            dst_array.mask = np.where(
-                f_array.mask, dst_array.mask, f_array.mask
-            ).astype(np.bool)
+            dst_array = ma.MaskedArray(
+                data=np.where(f_array.mask, dst_array, f_array).astype(dst_array.dtype),
+                mask=np.where(f_array.mask, dst_array.mask, f_array.mask).astype(np.bool)
+            )
         return dst_array
     else:
         input_file = input_files

--- a/mapchete/io/raster.py
+++ b/mapchete/io/raster.py
@@ -102,7 +102,7 @@ def _read_raster_window(
         # read subsequent files and merge
         for f in input_files[1:]:
             f_array = _read_raster_window(
-                input_files[0],
+                f,
                 tile=tile,
                 indexes=indexes,
                 resampling=resampling,

--- a/mapchete/io/raster.py
+++ b/mapchete/io/raster.py
@@ -343,7 +343,11 @@ def extract_from_array(in_raster=None, in_affine=None, out_tile=None):
 
 
 def resample_from_array(
-    in_raster=None, in_affine=None, in_crs=None, out_tile=None, resampling="nearest",
+    in_raster=None,
+    in_affine=None,
+    out_tile=None,
+    in_crs=None,
+    resampling="nearest",
     nodataval=0
 ):
     """

--- a/mapchete/io/vector.py
+++ b/mapchete/io/vector.py
@@ -157,7 +157,7 @@ def segmentize_geometry(geometry, segmentize_value):
     )
 
 
-def read_vector_window(input_file, tile, validity_check=True):
+def read_vector_window(input_files, tile, validity_check=True):
     """
     Read a window of an input vector dataset.
 
@@ -178,6 +178,18 @@ def read_vector_window(input_file, tile, validity_check=True):
     features : list
       a list of reprojected GeoJSON-like features
     """
+    if not isinstance(input_files, list):
+        input_files = [input_files]
+    return [
+        feature
+        for feature in chain.from_iterable([
+            _read_vector_window(path, tile, validity_check=validity_check)
+            for path in input_files
+        ])
+    ]
+
+
+def _read_vector_window(input_file, tile, validity_check=True):
     if tile.pixelbuffer and tile.is_on_edge():
         tile_boxes = clip_geometry_to_srs_bounds(
             tile.bbox, tile.tile_pyramid, multipart=True

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -313,6 +313,13 @@ def cleantopo_br_tiledir():
 
 
 @pytest.fixture
+def cleantopo_br_mercator():
+    """Fixture for cleantopo_br_mercator.mapchete."""
+    path = os.path.join(TESTDATA_DIR, "cleantopo_br_mercator.mapchete")
+    return ExampleConfig(path=path, dict=_dict_from_mapchete(path))
+
+
+@pytest.fixture
 def geojson():
     """Fixture for geojson.mapchete."""
     path = os.path.join(TESTDATA_DIR, "geojson.mapchete")

--- a/test/test_formats_tiledir_input.py
+++ b/test/test_formats_tiledir_input.py
@@ -78,6 +78,25 @@ def _run_tiledir_process_raster(conf_dict, metatiling, bounds):
         shutil.rmtree(mp.config.output.path, ignore_errors=True)
 
 
+def test_read_reprojected_raster_data(mp_tmpdir, cleantopo_br, cleantopo_br_mercator):
+    """Read reprojected raster data."""
+    zoom = 4
+    # prepare data
+    with mapchete.open(cleantopo_br.path) as mp:
+        mp.batch_process(zoom=zoom)
+
+    with mapchete.open(cleantopo_br_mercator.dict, mode="overwrite") as mp:
+        # read some data
+        assert any([
+            next(iter(mp.config.input.values())).open(tile).read().any()
+            for tile in mp.get_process_tiles(zoom)
+        ])
+        # read empty tile
+        assert not next(iter(mp.config.input.values())).open(
+            mp.config.process_pyramid.tile(zoom, 0, 0)
+        ).read().any()
+
+
 def test_read_from_dir(mp_tmpdir, cleantopo_br, cleantopo_br_tiledir):
     """Read raster data."""
     # prepare data

--- a/test/test_formats_tiledir_input.py
+++ b/test/test_formats_tiledir_input.py
@@ -95,6 +95,27 @@ def test_read_reprojected_raster_data(mp_tmpdir, cleantopo_br, cleantopo_br_merc
         assert not next(iter(mp.config.input.values())).open(
             mp.config.process_pyramid.tile(zoom, 0, 0)
         ).read().any()
+        # read from fixed zoom
+        assert not any([
+            next(iter(mp.config.input.values())).open(
+                tile, tile_directory_zoom=5
+            ).read().any()
+            for tile in mp.get_process_tiles(zoom)
+        ])
+        # read using maxzoom
+        assert not any([
+            next(iter(mp.config.input.values())).open(
+                tile, matching_max_zoom=3
+            ).read().any()
+            for tile in mp.get_process_tiles(zoom)
+        ])
+        # use fallback zoom
+        assert any([
+            next(iter(mp.config.input.values())).open(
+                tile, fallback_to_higher_zoom=True
+            ).read().any()
+            for tile in mp.get_process_tiles(5)
+        ])
 
 
 def test_read_from_dir(mp_tmpdir, cleantopo_br, cleantopo_br_tiledir):

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -700,7 +700,7 @@ def test_tile_to_zoom_level():
     assert tile_to_zoom_level(
         tp_merc.tile(zoom, 0, col),
         tp_geod,
-        method="min"
+        matching_method="min"
     ) == 12
     # at Equator
     assert tile_to_zoom_level(
@@ -710,7 +710,7 @@ def test_tile_to_zoom_level():
     assert tile_to_zoom_level(
         tp_merc.tile(zoom, tp_merc.matrix_height(zoom) // 2, col),
         tp_geod,
-        method="min"
+        matching_method="min"
     ) == 9
     # at Southern boundary
     assert tile_to_zoom_level(
@@ -720,7 +720,7 @@ def test_tile_to_zoom_level():
     assert tile_to_zoom_level(
         tp_merc.tile(zoom, tp_merc.matrix_height(zoom) - 1, col),
         tp_geod,
-        method="min"
+        matching_method="min"
     ) == 12
 
     # geodetic from mercator
@@ -733,7 +733,7 @@ def test_tile_to_zoom_level():
         tile_to_zoom_level(
             tp_geod.tile(zoom, 0, col),
             tp_merc,
-            method="min"
+            matching_method="min"
         )
     # at Equator
     assert tile_to_zoom_level(
@@ -743,7 +743,7 @@ def test_tile_to_zoom_level():
     assert tile_to_zoom_level(
         tp_geod.tile(zoom, tp_geod.matrix_height(zoom) // 2, col),
         tp_merc,
-        method="min"
+        matching_method="min"
     ) == 10
     # at Southern boundary
     assert tile_to_zoom_level(
@@ -754,7 +754,7 @@ def test_tile_to_zoom_level():
         tile_to_zoom_level(
             tp_geod.tile(zoom, tp_geod.matrix_height(zoom) - 1, col),
             tp_merc,
-            method="min"
+            matching_method="min"
         )
 
     # check wrong method
@@ -762,5 +762,5 @@ def test_tile_to_zoom_level():
         tile_to_zoom_level(
             tp_geod.tile(zoom, tp_geod.matrix_height(zoom) - 1, col),
             tp_merc,
-            method="invalid_method"
+            matching_method="invalid_method"
         )

--- a/test/test_mapchete.py
+++ b/test/test_mapchete.py
@@ -160,15 +160,13 @@ def test_get_raw_output_continue_vector(mp_tmpdir, geojson):
         assert mp.get_raw_output(tile)
 
 
-def test_get_raw_output_reproject(mp_tmpdir, cleantopo_tl):
-    """Get process output from a different CRS."""
-    try:
-        with mapchete.open(cleantopo_tl.path) as mp:
-            assert mp.config.mode == "continue"
-            # TODO implement function
-            mp.get_raw_output((5, 0, 0))
-    except NotImplementedError:
-        pass
+# def test_get_raw_output_reproject(mp_tmpdir, cleantopo_tl):
+#     """Get process output from a different CRS."""
+#     with pytest.raises(NotImplementedError):
+#         with mapchete.open(cleantopo_tl.path) as mp:
+#             assert mp.config.mode == "continue"
+#             # TODO implement function
+#             print(mp.get_raw_output((5, 0, 0)))
 
 
 def test_baselevels(mp_tmpdir, baselevels):

--- a/test/testdata/cleantopo_br_mercator.mapchete
+++ b/test/testdata/cleantopo_br_mercator.mapchete
@@ -1,0 +1,16 @@
+process: ../example_process.py
+zoom_levels:
+    min: 0
+    max: 5
+pyramid:
+    grid: mercator
+    pixelbuffer: 20
+    metatiling: 2
+input:
+    file1: tmp/cleantopo_br
+output:
+    dtype: uint16
+    bands: 1
+    format: GTiff
+    path: tmp/cleantopo_br_mercator
+    pixelbuffer: 20

--- a/test/testdata/cleantopo_br_mercator.mapchete
+++ b/test/testdata/cleantopo_br_mercator.mapchete
@@ -14,3 +14,4 @@ output:
     format: GTiff
     path: tmp/cleantopo_br_mercator
     pixelbuffer: 20
+bounds: [18834424.718692508, -35389629.4588656, 20037508.3427892, 20037508.3427892]


### PR DESCRIPTION
* `mapchete` outputs in a different CRS can now be opened as input of another process; various options of selecting the appropriate grid (i.e. zoom level) can be used
* `read_raster_window()` and `read_vector_window()` functions accept multiple paths and can now be used to merge outputs
* `mapchete.io` package has `tile_to_zoom_level()` function which can determine the appropriate zoom level of a tile pyramid in a different CRS

PR closes #71 