### PR TITLE
Tiledir custom grid

### DIFF
--- a/mapchete/cli/default/serve.py
+++ b/mapchete/cli/default/serve.py
@@ -77,7 +77,7 @@ def create_app(
 
     mp = next(iter(mapchete_processes.values()))
     pyramid_type = mp.config.process_pyramid.grid
-    pyramid_srid = mp.config.process_pyramid.srid
+    pyramid_srid = mp.config.process_pyramid.crs.to_epsg()
     process_bounds = ",".join([str(i) for i in mp.config.bounds_at_zoom()])
     grid = "g" if pyramid_srid == 3857 else "WGS84"
     web_pyramid = BufferedTilePyramid(pyramid_type)

--- a/mapchete/formats/__init__.py
+++ b/mapchete/formats/__init__.py
@@ -7,9 +7,12 @@ This module deserves a cleaner rewrite some day.
 import logging
 import os
 import pkg_resources
+from pprint import pformat
 import warnings
 
-from mapchete import errors
+from mapchete.errors import MapcheteConfigError, MapcheteDriverError
+from mapchete.io import read_json, write_json
+from mapchete.tile import BufferedTilePyramid
 
 DRIVERS_ENTRY_POINT = "mapchete.formats.drivers"
 
@@ -29,8 +32,10 @@ def _file_ext_to_driver():
             _driver = v.load()
             if not hasattr(_driver, "METADATA"):
                 warnings.warn(
-                    "driver %s cannot be loaded, METADATA is missing" % (
-                        str(v).split(" ")[-1]
+                    DeprecationWarning(
+                        "driver %s cannot be loaded, METADATA is missing" % (
+                            str(v).split(" ")[-1]
+                        )
                     )
                 )
                 continue
@@ -46,7 +51,7 @@ def _file_ext_to_driver():
             except Exception:
                 pass
         if not _FILE_EXT_TO_DRIVER:
-            raise errors.MapcheteDriverError("no drivers could be found")
+            raise MapcheteDriverError("no drivers could be found")
         return _FILE_EXT_TO_DRIVER
 
 
@@ -107,9 +112,7 @@ def load_output_writer(output_params, readonly=False):
             _driver.METADATA["driver_name"] == driver_name
         ):
             return _driver.OutputData(output_params, readonly=readonly)
-    raise errors.MapcheteDriverError(
-        "no loader for driver '%s' could be found." % driver_name
-    )
+    raise MapcheteDriverError("no loader for driver '%s' could be found." % driver_name)
 
 
 def load_input_reader(input_params, readonly=False):
@@ -134,15 +137,14 @@ def load_input_reader(input_params, readonly=False):
             logger.debug("%s is a directory", input_params["path"])
             driver_name = "TileDirectory"
     else:
-        raise errors.MapcheteDriverError("invalid input parameters %s" % input_params)
+        raise MapcheteDriverError("invalid input parameters %s" % input_params)
     for v in pkg_resources.iter_entry_points(DRIVERS_ENTRY_POINT):
         driver_ = v.load()
         if hasattr(driver_, "METADATA") and (
             driver_.METADATA["driver_name"] == driver_name
         ):
             return v.load().InputData(input_params, readonly=readonly)
-    raise errors.MapcheteDriverError(
-        "no loader for driver '%s' could be found." % driver_name)
+    raise MapcheteDriverError("no loader for driver '%s' could be found." % driver_name)
 
 
 def driver_from_file(input_file):
@@ -156,12 +158,93 @@ def driver_from_file(input_file):
     """
     file_ext = os.path.splitext(input_file)[1].split(".")[1]
     if file_ext not in _file_ext_to_driver():
-        raise errors.MapcheteDriverError(
+        raise MapcheteDriverError(
             "no driver could be found for file extension %s" % file_ext
         )
     driver = _file_ext_to_driver()[file_ext]
     if len(driver) > 1:
         warnings.warn(
-            "more than one driver for file found, taking %s" % driver[0]
+            DeprecationWarning(
+                "more than one driver for file found, taking %s" % driver[0]
+            )
         )
     return driver[0]
+
+
+def params_to_dump(params):
+    # in case GridDefinition was not yet initialized
+    return dict(
+        pyramid=BufferedTilePyramid(
+            grid=params["grid"],
+            tile_size=params.get("tile_size", 256),
+            metatiling=params.get("metatiling", 1),
+            pixelbuffer=params.get("pixelbuffer", 0),
+        ).to_dict(),
+        driver={
+           k: v
+           for k, v in params.items()
+           if k not in ["path", "grid", "pixelbuffer", "metatiling"]
+        }
+    )
+
+
+def read_output_metadata(metadata_json):
+    params = read_json(metadata_json)
+    grid = params["pyramid"]["grid"]
+    if grid["type"] == "geodetic" and grid["shape"] == [2, 1]:
+        warnings.warn(
+            DeprecationWarning(
+                """Deprecated grid shape ordering found. """
+                """Please change grid shape from [2, 1] to [1, 2] in %s."""
+                % metadata_json
+            )
+        )
+        params["pyramid"]["grid"]["shape"] = [1, 2]
+    params.update(
+        pyramid=BufferedTilePyramid(
+            params["pyramid"]["grid"],
+            metatiling=params["pyramid"].get("metatiling", 1),
+            tile_size=params["pyramid"].get("tile_size", 256),
+            pixelbuffer=params["pyramid"].get("pixelbuffer", 0)
+        )
+    )
+    return params
+
+
+def write_output_metadata(output_params):
+    """Dump output JSON and verify parameters if output metadata exist."""
+    if "path" in output_params:
+        metadata_path = os.path.join(output_params["path"], "metadata.json")
+        logger.debug("check for output %s", metadata_path)
+        try:
+            existing_params = read_output_metadata(metadata_path)
+            logger.debug("%s exists", metadata_path)
+            logger.debug("existing output parameters: %s", pformat(existing_params))
+            existing_tp = existing_params["pyramid"]
+            current_params = params_to_dump(output_params)
+            logger.debug("current output parameters: %s", pformat(current_params))
+            current_tp = BufferedTilePyramid(**current_params["pyramid"])
+            if existing_tp != current_tp:
+                raise MapcheteConfigError(
+                    "pyramid definitions between existing and new output do not match: "
+                    "%s != %s" % (existing_tp, current_tp)
+                )
+            existing_format = existing_params["driver"]["format"]
+            current_format = current_params["driver"]["format"]
+            if existing_format != current_format:
+                raise MapcheteConfigError(
+                    "existing output format does not match new output format: "
+                    "%s != %s" % (
+                        (existing_format, current_format)
+                    )
+                )
+        except FileNotFoundError:
+            logger.debug("%s does not exist", metadata_path)
+            dump_params = params_to_dump(output_params)
+            # dump output metadata
+            try:
+                write_json(metadata_path, dump_params)
+            except Exception as e:
+                logger.warning("failed to write %s: %s", metadata_path, e)
+    else:
+        logger.debug("no path parameter found")

--- a/mapchete/formats/default/geojson.py
+++ b/mapchete/formats/default/geojson.py
@@ -81,7 +81,7 @@ class OutputData(base.OutputData):
         self.output_params = output_params
         self._bucket = self.path.split("/")[2] if self.path.startswith("s3://") else None
 
-    def read(self, output_tile):
+    def read(self, output_tile, **kwargs):
         """
         Read existing process output.
 
@@ -255,7 +255,7 @@ class InputTile(base.InputTile):
         self.process = process
         self._cache = {}
 
-    def read(self, validity_check=True, no_neighbors=False):
+    def read(self, validity_check=True, no_neighbors=False, **kwargs):
         """
         Read data from process output.
 

--- a/mapchete/formats/default/gtiff.py
+++ b/mapchete/formats/default/gtiff.py
@@ -102,7 +102,7 @@ class OutputData(base.OutputData):
         self.nodata = output_params.get("nodata", GTIFF_DEFAULT_PROFILE["nodata"])
         self._bucket = self.path.split("/")[2] if self.path.startswith("s3://") else None
 
-    def read(self, output_tile):
+    def read(self, output_tile, **kwargs):
         """
         Read existing process output.
 
@@ -248,7 +248,7 @@ class OutputData(base.OutputData):
         try:
             if "compression" in self.output_params:
                 warnings.warn(
-                    "use 'compress' instead of 'compression'", DeprecationWarning
+                    DeprecationWarning("use 'compress' instead of 'compression'")
                 )
                 dst_metadata.update(compress=self.output_params["compression"])
             else:
@@ -339,7 +339,7 @@ class InputTile(base.InputTile):
         self.pixelbuffer = None
         self.resampling = resampling
 
-    def read(self, indexes=None):
+    def read(self, indexes=None, **kwargs):
         """
         Read reprojected & resampled input data.
 
@@ -357,9 +357,7 @@ class InputTile(base.InputTile):
         if len(band_indexes) == 1:
             return arr[band_indexes[0] - 1]
         else:
-            return ma.concatenate([
-                ma.expand_dims(arr[i - 1], 0) for i in band_indexes
-            ])
+            return ma.concatenate([ma.expand_dims(arr[i - 1], 0) for i in band_indexes])
 
     def is_empty(self, indexes=None):
         """

--- a/mapchete/formats/default/mapchete_input.py
+++ b/mapchete/formats/default/mapchete_input.py
@@ -85,4 +85,5 @@ class InputData(base.InputData):
         return reproject_geometry(
             self.process.config.area_at_zoom(),
             src_crs=self.process.config.process_pyramid.crs,
-            dst_crs=self.pyramid.crs if out_crs is None else out_crs)
+            dst_crs=self.pyramid.crs if out_crs is None else out_crs
+        )

--- a/mapchete/formats/default/png.py
+++ b/mapchete/formats/default/png.py
@@ -120,7 +120,7 @@ class OutputData(base.OutputData):
                     bucket_resource=bucket_resource
                 )
 
-    def read(self, output_tile):
+    def read(self, output_tile, **kwargs):
         """
         Read existing process output.
 

--- a/mapchete/formats/default/png_hillshade.py
+++ b/mapchete/formats/default/png_hillshade.py
@@ -24,12 +24,10 @@ import logging
 import numpy as np
 import numpy.ma as ma
 import os
-import rasterio
-from rasterio.errors import RasterioIOError
 
 from mapchete.config import validate_values
 from mapchete.formats import base
-from mapchete.io import GDAL_HTTP_OPTS, makedirs, get_boto3_bucket
+from mapchete.io import makedirs, get_boto3_bucket
 from mapchete.io.raster import (
     write_raster_window, prepare_array, memory_file, read_raster_no_crs
 )
@@ -129,7 +127,7 @@ class OutputData(base.OutputData):
                     bucket_resource=bucket_resource
                 )
 
-    def read(self, output_tile):
+    def read(self, output_tile, **kwargs):
         """
         Read existing process output.
 

--- a/mapchete/formats/default/raster_file.py
+++ b/mapchete/formats/default/raster_file.py
@@ -161,7 +161,7 @@ class InputTile(base.InputTile):
         else:
             self.gdal_opts = {}
 
-    def read(self, indexes=None):
+    def read(self, indexes=None, **kwargs):
         """
         Read reprojected & resampled input data.
 
@@ -220,5 +220,5 @@ def get_segmentize_value(input_file=None, tile_pyramid=None):
     segmenize value : float
         length suggested of line segmentation to reproject file bounds
     """
-    warnings.warn("get_segmentize_value() has moved to mapchete.io")
+    warnings.warn(DeprecationWarning("get_segmentize_value() has moved to mapchete.io"))
     return io.get_segmentize_value(input_file, tile_pyramid)

--- a/mapchete/formats/default/vector_file.py
+++ b/mapchete/formats/default/vector_file.py
@@ -115,7 +115,7 @@ class InputTile(base.InputTile):
         self.vector_file = vector_file
         self._cache = {}
 
-    def read(self, validity_check=True):
+    def read(self, validity_check=True, **kwargs):
         """
         Read reprojected & resampled input data.
 

--- a/mapchete/log.py
+++ b/mapchete/log.py
@@ -54,7 +54,10 @@ def setup_logfile(logfile):
 def user_process_logger(pname):
     """Logger to be used within a user process file."""
     warnings.warn(
-        "user_process_logger() deprecated, you can use standard logging module instead."
+        DeprecationWarning(
+            "user_process_logger() deprecated, you can use standard logging module "
+            "instead."
+        )
     )
     return logging.getLogger("mapchete.user_process." + pname)
 
@@ -62,6 +65,8 @@ def user_process_logger(pname):
 def driver_logger(dname):
     """Logger to be used from a driver plugin."""
     warnings.warn(
-        "driver_logger() deprecated, you can use standard logging module instead."
+        DeprecationWarning(
+            "driver_logger() deprecated, you can use standard logging module instead."
+        )
     )
     return logging.getLogger("mapchete.formats.drivers." + dname)

--- a/mapchete/tile.py
+++ b/mapchete/tile.py
@@ -28,13 +28,11 @@ class BufferedTilePyramid(TilePyramid):
     """
 
     def __init__(
-        self, pyramid_type, metatiling=1, tile_size=256, pixelbuffer=0
+        self, grid=None, metatiling=1, tile_size=256, pixelbuffer=0
     ):
         """Initialize."""
-        TilePyramid.__init__(
-            self, pyramid_type, metatiling=metatiling, tile_size=tile_size)
-        self.tile_pyramid = TilePyramid(
-            pyramid_type, metatiling=metatiling, tile_size=tile_size)
+        TilePyramid.__init__(self, grid, metatiling=metatiling, tile_size=tile_size)
+        self.tile_pyramid = TilePyramid(grid, metatiling=metatiling, tile_size=tile_size)
         self.metatiling = metatiling
         if isinstance(pixelbuffer, int) and pixelbuffer >= 0:
             self.pixelbuffer = pixelbuffer
@@ -129,7 +127,30 @@ class BufferedTilePyramid(TilePyramid):
         """
         return [
             self.tile(*intersecting_tile.id)
-            for intersecting_tile in self.tile_pyramid.intersecting(tile)]
+            for intersecting_tile in self.tile_pyramid.intersecting(tile)
+        ]
+
+    def to_dict(self):
+        """
+        Return dictionary representation of pyramid parameters.
+        """
+        return dict(
+            grid=self.grid.to_dict(),
+            metatiling=self.metatiling,
+            tile_size=self.tile_size,
+            pixelbuffer=self.pixelbuffer
+        )
+
+    def from_dict(config_dict):
+        """
+        Initialize TilePyramid from configuration dictionary.
+        """
+        return BufferedTilePyramid(**config_dict)
+
+    def __repr__(self):
+        return 'BufferedTilePyramid(%s, tile_size=%s, metatiling=%s, pixelbuffer=%s)' % (
+            self.grid, self.tile_size, self.metatiling, self.pixelbuffer
+        )
 
 
 class BufferedTile(Tile):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -104,6 +104,22 @@ def http_metadata_json():
 
 
 @pytest.fixture
+def old_style_metadata_json():
+    """
+    Fixture for old_style_metadata.json.
+    """
+    return os.path.join(TESTDATA_DIR, "old_style_metadata.json")
+
+
+@pytest.fixture
+def old_geodetic_shape_metadata_json():
+    """
+    Fixture for old_geodetic_shape_metadata.json.
+    """
+    return os.path.join(TESTDATA_DIR, "old_geodetic_shape_metadata.json")
+
+
+@pytest.fixture
 def landpoly():
     """Fixture for landpoly.geojson."""
     return os.path.join(TESTDATA_DIR, "landpoly.geojson")

--- a/test/test_formats.py
+++ b/test/test_formats.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Test Mapchete default formats."""
 
 import pytest
@@ -77,7 +76,6 @@ def test_base_format_classes():
     assert tmp.pyramid
     assert tmp.pixelbuffer == 0
     assert tmp.crs
-    assert tmp.srid
     with pytest.raises(NotImplementedError):
         tmp.open(None)
     with pytest.raises(NotImplementedError):
@@ -93,11 +91,10 @@ def test_base_format_classes():
         tmp.is_empty()
 
     # OutputData
-    tmp = base.OutputData(dict(pixelbuffer=0, type="geodetic", metatiling=1))
+    tmp = base.OutputData(dict(pixelbuffer=0, grid="geodetic", metatiling=1))
     assert tmp.pyramid
     assert tmp.pixelbuffer == 0
     assert tmp.crs
-    assert tmp.srid
     with pytest.raises(NotImplementedError):
         tmp.read(None)
     with pytest.raises(NotImplementedError):

--- a/test/test_formats.py
+++ b/test/test_formats.py
@@ -8,7 +8,7 @@ import mapchete
 from mapchete import MapcheteProcess, errors
 from mapchete.formats import (
     available_input_formats, available_output_formats, driver_from_file, base,
-    load_output_writer, load_input_reader
+    load_output_writer, load_input_reader, read_output_metadata
 )
 
 
@@ -145,3 +145,11 @@ def test_invalid_input_type(example_mapchete):
     config.update(input=dict(invalid_type=1))
     with pytest.raises(errors.MapcheteConfigError):
         mapchete.open(config)
+
+
+def test_old_style_metadata(old_style_metadata_json, old_geodetic_shape_metadata_json):
+    # deprecated CRS definitions
+    assert read_output_metadata(old_style_metadata_json)
+    # deprecated geodetic shape
+    params = read_output_metadata(old_geodetic_shape_metadata_json)
+    assert params["pyramid"].grid.type == "geodetic"

--- a/test/test_formats_geojson.py
+++ b/test/test_formats_geojson.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Test GeoJSON as process output."""
 
 from shapely.geometry import shape
@@ -65,7 +64,7 @@ def test_for_web(client, mp_tmpdir):
 def test_output_data(mp_tmpdir, geojson):
     """Check GeoJSON as output data."""
     output_params = dict(
-        type="geodetic",
+        grid="geodetic",
         format="GeoJSON",
         path=mp_tmpdir,
         schema=dict(properties=dict(id="int"), geometry="Polygon"),
@@ -93,7 +92,7 @@ def test_output_data(mp_tmpdir, geojson):
 def test_s3_output_data(mp_s3_tmpdir, geojson_s3):
     """Check GeoJSON as output data."""
     output_params = dict(
-        type="geodetic",
+        grid="geodetic",
         format="GeoJSON",
         path=mp_s3_tmpdir,
         schema=dict(properties=dict(id="int"), geometry="Polygon"),

--- a/test/test_formats_geotiff.py
+++ b/test/test_formats_geotiff.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Test GeoTIFF as process output."""
 
 import numpy as np
@@ -16,7 +15,7 @@ from mapchete.tile import BufferedTilePyramid
 def test_output_data(mp_tmpdir):
     """Check GeoTIFF as output data."""
     output_params = dict(
-        type="geodetic",
+        grid="geodetic",
         format="GeoTIFF",
         path=mp_tmpdir,
         pixelbuffer=0,
@@ -112,7 +111,7 @@ def test_input_data(mp_tmpdir, cleantopo_br):
         # TODO tile with existing but empty data
         tile = tp.tile(5, 5, 5)
         output_params = dict(
-            type="geodetic",
+            grid="geodetic",
             format="GeoTIFF",
             path=mp_tmpdir,
             pixelbuffer=0,

--- a/test/test_formats_png.py
+++ b/test/test_formats_png.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Test PNG as process output."""
 
 import numpy as np
@@ -14,7 +13,7 @@ from mapchete.tile import BufferedTilePyramid
 def test_output_data(mp_tmpdir):
     """Check PNG as output data."""
     output_params = dict(
-        type="geodetic",
+        grid="geodetic",
         format="PNG",
         path=mp_tmpdir,
         pixelbuffer=0,
@@ -74,7 +73,7 @@ def test_output_data(mp_tmpdir):
 def test_s3_write_output_data(mp_s3_tmpdir):
     """Write and read output."""
     output_params = dict(
-        type="geodetic",
+        grid="geodetic",
         format="PNG",
         path=mp_s3_tmpdir,
         pixelbuffer=0,

--- a/test/test_formats_png_hillshade.py
+++ b/test/test_formats_png_hillshade.py
@@ -13,7 +13,7 @@ from mapchete.tile import BufferedTilePyramid
 def test_output_data(mp_tmpdir):
     """Check PNG_hillshade as output data."""
     output_params = dict(
-        type="geodetic",
+        grid="geodetic",
         format="PNG_hillshade",
         path=mp_tmpdir,
         pixelbuffer=0,
@@ -97,7 +97,7 @@ def test_output_data(mp_tmpdir):
 def test_s3_write_output_data(mp_s3_tmpdir):
     """Write and read output."""
     output_params = dict(
-        type="geodetic",
+        grid="geodetic",
         format="PNG_hillshade",
         path=mp_s3_tmpdir,
         pixelbuffer=0,

--- a/test/test_formats_tiledir_input.py
+++ b/test/test_formats_tiledir_input.py
@@ -4,10 +4,9 @@ from copy import deepcopy
 import pytest
 import shutil
 
+import mapchete
 from mapchete.formats import available_input_formats
 from mapchete.errors import MapcheteDriverError
-
-import mapchete
 
 
 def test_driver_available():
@@ -156,12 +155,12 @@ def test_parse_errors(geojson_tiledir, cleantopo_br_tiledir):
         mapchete.open(vector_type)
     # without type
     vector_type = deepcopy(geojson_tiledir.dict)
-    vector_type["input"]["file1"].pop("type")
+    vector_type["input"]["file1"].pop("grid")
     with pytest.raises(MapcheteDriverError):
         mapchete.open(vector_type)
     # wrong type
     vector_type = deepcopy(geojson_tiledir.dict)
-    vector_type["input"]["file1"]["type"] = "invalid"
+    vector_type["input"]["file1"]["grid"] = "invalid"
     with pytest.raises(MapcheteDriverError):
         mapchete.open(vector_type)
     # without extension

--- a/test/testdata/cleantopo_br_tiledir.mapchete
+++ b/test/testdata/cleantopo_br_tiledir.mapchete
@@ -11,7 +11,7 @@ input:
         format: TileDirectory
         path: tmp/cleantopo_br
         metatiling: 8
-        type: geodetic
+        grid: geodetic
         extension: tif
         dtype: uint16
         count: 1

--- a/test/testdata/cleantopo_remote.mapchete
+++ b/test/testdata/cleantopo_remote.mapchete
@@ -9,7 +9,7 @@ input:
         format: TileDirectory
         path: https://ungarj.github.io/mapchete_testdata/tiled_data/raster/cleantopo
         metatiling: 1
-        type: geodetic
+        grid: geodetic
         extension: tif
         dtype: uint16
         count: 1

--- a/test/testdata/deprecated_params.mapchete
+++ b/test/testdata/deprecated_params.mapchete
@@ -6,7 +6,7 @@ input_files:
         zoom>=10: dummy1.tif
     file2: dummy2.tif
 output:
-    type: geodetic
+    grid: geodetic
     path: tmp/deprecated_params
     format: GTiff
     dtype: float32

--- a/test/testdata/geojson.mapchete
+++ b/test/testdata/geojson.mapchete
@@ -6,7 +6,7 @@ pyramid:
 input:
     file1: antimeridian.geojson
 output:
-    type: geodetic
+    grid: geodetic
     format: GeoJSON
     path: tmp/geojson
     data_type: vector

--- a/test/testdata/geojson_tiledir.mapchete
+++ b/test/testdata/geojson_tiledir.mapchete
@@ -8,7 +8,7 @@ input:
         format: TileDirectory
         path: tmp/geojson
         metatiling: 2
-        type: geodetic
+        grid: geodetic
         extension: geojson
 output:
     format: GeoJSON

--- a/test/testdata/old_geodetic_shape_metadata.json
+++ b/test/testdata/old_geodetic_shape_metadata.json
@@ -1,0 +1,30 @@
+{
+    "driver": {
+        "dtype": "uint8",
+        "format": "PNG_hillshade"
+    },
+    "pyramid": {
+        "grid": {
+            "bottom": -90.0,
+            "bounds": [
+                -180.0,
+                -90.0,
+                180.0,
+                90.0
+            ],
+            "crs": "EPSG:4326",
+            "is_global": true,
+            "left": -180.0,
+            "right": 180.0,
+            "shape": [
+                2,
+                1
+            ],
+            "srid": 4326,
+            "top": 90.0,
+            "type": "geodetic"
+        },
+        "metatiling": 1,
+        "pixelbuffer": 0
+    }
+}

--- a/test/testdata/old_style_metadata.json
+++ b/test/testdata/old_style_metadata.json
@@ -1,0 +1,33 @@
+{
+    "driver": {
+        "bands": 3,
+        "compress": "deflate",
+        "dtype": "uint8",
+        "format": "GTiff",
+        "predictor": 2
+    },
+    "pyramid": {
+        "grid": {
+            "bottom": 89840,
+            "bounds": [
+                141920,
+                89840,
+                948320,
+                502000
+            ],
+            "crs": "EPSG:31259",
+            "is_global": false,
+            "left": 141920,
+            "right": 948320,
+            "shape": [
+                161,
+                315
+            ],
+            "srid": 31259,
+            "top": 502000,
+            "type": "custom"
+        },
+        "metatiling": 4,
+        "pixelbuffer": 0
+    }
+}


### PR DESCRIPTION
- `TileDirectory` input can now handle custom grids
- use `tilematrix` `to_dict()` and `from_dict()` functions to dump & load `TilePyramid` configurations
- properly use `DeprecationWarning` in `warnings.warn()` calls
- move `params_to_dump()`, `read_output_metadata()` and `write_output_metadata()` from `io` to `formats`