### PR TITLE
use init_bounds instead of pyramid bounds on readonly mode

### DIFF
--- a/mapchete/config.py
+++ b/mapchete/config.py
@@ -546,7 +546,7 @@ class MapcheteConfig(object):
         process area : shapely geometry
         """
         if not self._init_inputs:
-            return box(*self.process_pyramid.bounds)
+            return box(*self.init_bounds)
         if zoom is None:
             if not self._cache_full_process_area:
                 logger.debug("calculate process area ...")


### PR DESCRIPTION
In readonly mode all init_bounds (e.g. through the --bounds parameter) are ignored and the default process pyramid bounds are used. This results in the inability to spatially subset the process area.