### PR TITLE
speed up extension loading

### DIFF
--- a/mapchete/_registered.py
+++ b/mapchete/_registered.py
@@ -1,0 +1,9 @@
+try:
+    from importlib import metadata
+except ImportError:
+    # <PY38 use backport
+    import importlib_metadata as metadata
+
+commands = metadata.entry_points().get("mapchete.cli.commands", ())
+drivers = metadata.entry_points().get("mapchete.formats.drivers", ())
+processes = metadata.entry_points().get("mapchete.processes", ())

--- a/mapchete/cli/default/create.py
+++ b/mapchete/cli/default/create.py
@@ -1,6 +1,7 @@
 """Create dummy Mapchete and python process files."""
 
 import click
+from importlib_resources import files
 import os
 from string import Template
 from shutil import copyfile
@@ -61,18 +62,15 @@ def create(
     out_path = out_path if out_path else os.path.join(os.getcwd(), "output")
 
     # copy file template to target directory
-    # process_template = pkg_resources.resource_filename(
-    #     "mapchete.static", "process_template.py"
-    # )
-    process_template = None
+    # Reads contents with UTF-8 encoding and returns str.
+    process_template = str(files("mapchete.static").joinpath("process_template.py"))
     process_file = os.path.join(os.getcwd(), process_file)
     copyfile(process_template, process_file)
 
     # modify and copy mapchete file template to target directory
-    # mapchete_template = pkg_resources.resource_filename(
-    #     "mapchete.static", "mapchete_template.mapchete"
-    # )
-    mapchete_template = None
+    mapchete_template = str(
+        files("mapchete.static").joinpath("mapchete_template.mapchete")
+    )
 
     output_options = dict(
         format=out_format, path=out_path, **FORMAT_MANDATORY[out_format]

--- a/mapchete/cli/default/create.py
+++ b/mapchete/cli/default/create.py
@@ -5,7 +5,6 @@ import os
 from string import Template
 from shutil import copyfile
 from oyaml import dump
-import pkg_resources
 
 from mapchete.cli import utils
 
@@ -13,18 +12,18 @@ FORMAT_MANDATORY = {
     "GTiff": {
         "bands": None,
         "dtype": None
-        },
+    },
     "PNG": {
         "bands": None,
         "dtype": None
-        },
+    },
     "PNG_hillshade": {
         "bands": 4,
         "dtype": "uint8"
-        },
+    },
     "GeoJSON": {
         "schema": {}
-        },
+    },
     "PostGIS": {
         "schema": {},
         "db_params": {
@@ -34,9 +33,9 @@ FORMAT_MANDATORY = {
             "user": None,
             "password": None,
             "table": None
-            }
         }
     }
+}
 
 
 @click.command(help="Create a new process.")
@@ -62,16 +61,18 @@ def create(
     out_path = out_path if out_path else os.path.join(os.getcwd(), "output")
 
     # copy file template to target directory
-    process_template = pkg_resources.resource_filename(
-        "mapchete.static", "process_template.py"
-    )
+    # process_template = pkg_resources.resource_filename(
+    #     "mapchete.static", "process_template.py"
+    # )
+    process_template = None
     process_file = os.path.join(os.getcwd(), process_file)
     copyfile(process_template, process_file)
 
     # modify and copy mapchete file template to target directory
-    mapchete_template = pkg_resources.resource_filename(
-        "mapchete.static", "mapchete_template.mapchete"
-    )
+    # mapchete_template = pkg_resources.resource_filename(
+    #     "mapchete.static", "mapchete_template.mapchete"
+    # )
+    mapchete_template = None
 
     output_options = dict(
         format=out_format, path=out_path, **FORMAT_MANDATORY[out_format]

--- a/mapchete/cli/main.py
+++ b/mapchete/cli/main.py
@@ -1,16 +1,13 @@
-"""
-Mapchete command line tool with subcommands.
-"""
-
-from pkg_resources import iter_entry_points
+"""Mapchete command line tool with subcommands."""
 
 import click
 from click_plugins import with_plugins
 
 from mapchete import __version__
+from mapchete._registered import commands
 
 
-@with_plugins(iter_entry_points('mapchete.cli.commands'))
+@with_plugins(commands)
 @click.version_option(version=__version__, message='%(version)s')
 @click.group()
 def main():

--- a/mapchete/log.py
+++ b/mapchete/log.py
@@ -11,7 +11,7 @@ import warnings
 
 from mapchete._registered import drivers, processes
 
-all_mapchete_packages = set(v.name.split(".")[0] for v in chain(drivers, processes))
+all_mapchete_packages = set(v.value.split(".")[0] for v in chain(drivers, processes))
 
 key_value_replace_patterns = {
     "AWS_ACCESS_KEY_ID": "***",

--- a/mapchete/log.py
+++ b/mapchete/log.py
@@ -7,16 +7,11 @@ correctly.
 """
 from itertools import chain
 import logging
-import pkg_resources
 import warnings
 
-all_mapchete_packages = set(
-    v.module_name.split(".")[0]
-    for v in chain(
-        pkg_resources.iter_entry_points("mapchete.formats.drivers"),
-        pkg_resources.iter_entry_points("mapchete.processes")
-    )
-)
+from mapchete._registered import drivers, processes
+
+all_mapchete_packages = set(v.name.split(".")[0] for v in chain(drivers, processes))
 
 key_value_replace_patterns = {
     "AWS_ACCESS_KEY_ID": "***",

--- a/mapchete/processes/__init__.py
+++ b/mapchete/processes/__init__.py
@@ -1,5 +1,6 @@
 import logging
-import pkg_resources
+
+from mapchete._registered import processes
 
 logger = logging.getLogger(__name__)
 
@@ -18,8 +19,6 @@ def registered_processes(process_name=None):
     module
     """
     def _import():
-        # get all registered processes by name
-        processes = list(pkg_resources.iter_entry_points("mapchete.processes"))
         # try to load processes
         for v in processes:
             logger.debug("try to load %s", v)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ click>=7.1.1
 click-plugins
 click-spinner
 fiona>=1.8b1
+importlib-metadata
 numpy>=1.16
 oyaml
 retry

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ click-plugins
 click-spinner
 fiona>=1.8b1
 importlib-metadata
+importlib-resources
 numpy>=1.16
 oyaml
 retry

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,4 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],
-    setup_requires=["pytest-runner"],
-    tests_require=["pytest", "pytest-flask", "rio-cogeo"]
 )


### PR DESCRIPTION
This aims to speed up loading additional drivers, CLI commands and processes which currently use the `pkg_resources` module which can be replaced by the faster `importlib-metadata` and
`importlib-resources` modules.

More details can be found on this [`setuptools` issue](https://github.com/pypa/setuptools/issues/510).

Still improvements can be made as it seems importing `rasterio` takes ~400ms alone.
