### PR TITLE
Pass `dask_scheduler` kwarg down to the `_processing.py`

### DIFF
--- a/mapchete/commands/_execute.py
+++ b/mapchete/commands/_execute.py
@@ -28,6 +28,7 @@ def execute(
     multiprocessing_start_method: str = None,
     msg_callback: Callable = None,
     as_iterator: bool = False,
+    dask_scheduler: str = ''
 ) -> Job:
     """
     Execute a Mapchete process.

--- a/mapchete/commands/_execute.py
+++ b/mapchete/commands/_execute.py
@@ -132,6 +132,7 @@ def execute(
             multiprocessing_start_method=multiprocessing_start_method,
             as_iterator=as_iterator,
             total=1 if tile else tiles_count,
+            dask_scheduler=dask_scheduler,
         )
     # explicitly exit the mp object on failure
     except Exception:  # pragma: no cover


### PR DESCRIPTION
* two liner which seems to have fixed the  entry into dask scheduler
* or rather just enables the utilization of this if clause https://github.com/ungarj/mapchete/blob/dask/mapchete/_distributed.py#L16