### PR TITLE
introduce pyproj to enable CRS bounds clip to other CRSes

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,9 +33,9 @@ jobs:
         RASTERIO_VERSION: ${{ matrix.rasterio-version }}
         CURL_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
       run: |
-        sudo apt-add-repository -y ppa:ubuntugis/ubuntugis-unstable && sudo apt-get -y update && sudo apt-get install -y gdal-bin python-tk libgdal-dev
+        sudo apt-add-repository -y ppa:ubuntugis/ubuntugis-unstable && sudo apt-get -y update && sudo apt-get install -y gdal-bin python-tk libgdal-dev libproj-dev
         python -m pip install --upgrade pip
-        pip install fiona shapely --no-binary :all:
+        pip install fiona proj shapely --no-binary :all:
         if [ $RASTERIO_VERSION == "latest" ]; then pip install rasterio --no-binary :all:; else pip install rasterio==$RASTERIO_VERSION --no-binary :all:; fi;
         pip install -e .[complete]
         pip install -r test/requirements.txt

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,9 +33,9 @@ jobs:
         RASTERIO_VERSION: ${{ matrix.rasterio-version }}
         CURL_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
       run: |
-        sudo apt-add-repository -y ppa:ubuntugis/ubuntugis-unstable && sudo apt-get -y update && sudo apt-get install -y gdal-bin python-tk libgdal-dev libproj-dev
+        sudo apt-add-repository -y ppa:ubuntugis/ubuntugis-unstable && sudo apt-get -y update && sudo apt-get install -y gdal-bin python-tk libgdal-dev
         python -m pip install --upgrade pip
-        pip install fiona pyproj shapely --no-binary :all:
+        pip install fiona shapely --no-binary :all:
         if [ $RASTERIO_VERSION == "latest" ]; then pip install rasterio --no-binary :all:; else pip install rasterio==$RASTERIO_VERSION --no-binary :all:; fi;
         pip install -e .[complete]
         pip install -r test/requirements.txt

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,9 +33,9 @@ jobs:
         RASTERIO_VERSION: ${{ matrix.rasterio-version }}
         CURL_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
       run: |
-        sudo apt-add-repository -y ppa:ubuntugis/ubuntugis-unstable && sudo apt-get -y update && sudo apt-get install -y gdal-bin python-tk libgdal-dev
+        sudo apt-add-repository -y ppa:ubuntugis/ubuntugis-unstable && sudo apt-get -y update && sudo apt-get install -y gdal-bin python-tk libgdal-dev libproj-dev
         python -m pip install --upgrade pip
-        pip install fiona shapely --no-binary :all:
+        pip install fiona pyproj shapely --no-binary :all:
         if [ $RASTERIO_VERSION == "latest" ]; then pip install rasterio --no-binary :all:; else pip install rasterio==$RASTERIO_VERSION --no-binary :all:; fi;
         pip install -e .[complete]
         pip install -r test/requirements.txt

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ 3.7, 3.8 ]
-        rasterio-version: [ 1.1.4, "latest" ]
         experimental: [ false ]
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
@@ -30,13 +29,10 @@ jobs:
 
     - name: Install dependencies
       env:
-        RASTERIO_VERSION: ${{ matrix.rasterio-version }}
         CURL_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
       run: |
         sudo apt-add-repository -y ppa:ubuntugis/ubuntugis-unstable && sudo apt-get -y update && sudo apt-get install -y gdal-bin python-tk libgdal-dev libproj-dev
         python -m pip install --upgrade pip
-        pip install fiona pyproj shapely --no-binary :all:
-        if [ $RASTERIO_VERSION == "latest" ]; then pip install rasterio --no-binary :all:; else pip install rasterio==$RASTERIO_VERSION --no-binary :all:; fi;
         pip install -e .[complete]
         pip install -r test/requirements.txt
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         sudo apt-add-repository -y ppa:ubuntugis/ubuntugis-unstable && sudo apt-get -y update && sudo apt-get install -y gdal-bin python-tk libgdal-dev libproj-dev
         python -m pip install --upgrade pip
-        pip install fiona proj shapely --no-binary :all:
+        pip install fiona pyproj shapely --no-binary :all:
         if [ $RASTERIO_VERSION == "latest" ]; then pip install rasterio --no-binary :all:; else pip install rasterio==$RASTERIO_VERSION --no-binary :all:; fi;
         pip install -e .[complete]
         pip install -r test/requirements.txt

--- a/mapchete/formats/default/tile_directory.py
+++ b/mapchete/formats/default/tile_directory.py
@@ -187,7 +187,7 @@ class InputData(base.InputData):
             box(*self._bounds),
             src_crs=self.td_pyramid.crs,
             dst_crs=self.pyramid.crs if out_crs is None else out_crs,
-            # segmentize_on_clip=True,
+            segmentize_on_clip=True,
         )
 
 

--- a/mapchete/formats/default/tile_directory.py
+++ b/mapchete/formats/default/tile_directory.py
@@ -187,7 +187,7 @@ class InputData(base.InputData):
             box(*self._bounds),
             src_crs=self.td_pyramid.crs,
             dst_crs=self.pyramid.crs if out_crs is None else out_crs,
-            segmentize_on_clip=True,
+            # segmentize_on_clip=True,
         )
 
 

--- a/mapchete/formats/default/tile_directory.py
+++ b/mapchete/formats/default/tile_directory.py
@@ -14,7 +14,7 @@ from mapchete.formats import (
     read_output_metadata,
 )
 from mapchete.io import path_exists, absolute_path, tile_to_zoom_level
-from mapchete.io.vector import reproject_geometry
+from mapchete.io.vector import reproject_geometry, segmentize_geometry
 from mapchete.tile import BufferedTilePyramid
 
 
@@ -187,6 +187,7 @@ class InputData(base.InputData):
             box(*self._bounds),
             src_crs=self.td_pyramid.crs,
             dst_crs=self.pyramid.crs if out_crs is None else out_crs,
+            segmentize_on_clip=True,
         )
 
 

--- a/mapchete/io/_geometry_operations.py
+++ b/mapchete/io/_geometry_operations.py
@@ -92,11 +92,18 @@ def reproject_geometry(
         dst_crs.is_epsg_code
         and dst_crs.get("init")
         != "epsg:4326"  # and is not WGS84 (does not need clipping)
-        and pyproj.CRS(dst_crs.to_epsg()).area_of_use.bounds
+        and (
+            dst_crs.get("init") in CRS_BOUNDS
+            or pyproj.CRS(dst_crs.to_epsg()).area_of_use.bounds
+        )
     ):
         wgs84_crs = CRS().from_epsg(4326)
         # get dst_crs boundaries
-        crs_bbox = box(*pyproj.CRS(dst_crs.to_epsg()).area_of_use.bounds)
+        crs_bbox = box(
+            *CRS_BOUNDS.get(
+                dst_crs.get("init"), pyproj.CRS(dst_crs.to_epsg()).area_of_use.bounds
+            )
+        )
         # reproject geometry to WGS84
         geometry_4326 = _reproject_geom(geometry, src_crs, wgs84_crs)
         # raise error if geometry has to be clipped

--- a/mapchete/io/_geometry_operations.py
+++ b/mapchete/io/_geometry_operations.py
@@ -1,5 +1,4 @@
 from fiona.transform import transform_geom
-import pyproj
 from rasterio.crs import CRS
 from shapely.errors import TopologicalError
 from shapely.geometry import (
@@ -29,6 +28,19 @@ CRS_BOUNDS = {
     # http://spatialreference.org/ref/epsg/3035/
     "epsg:3035": (-10.6700, 34.5000, 31.5500, 71.0500),
 }
+
+
+def _get_utm_bounds():
+    # UTM stripe bounds per hemisphere (6 for North, 7 for South)
+    bounds = {6: (12.0, 0.0, 18.0, 84.0), 7: (12.0, -80.0, 18.0, 0.0)}
+    return {
+        f"epsg:32{hemisphere}{stripe + 1}": bounds[hemisphere]
+        for stripe in range(60)
+        for hemisphere in [6, 7]
+    }
+
+
+CRS_BOUNDS.update(_get_utm_bounds())
 
 
 def reproject_geometry(
@@ -94,18 +106,11 @@ def reproject_geometry(
         dst_crs.is_epsg_code
         and dst_crs.get("init")
         != "epsg:4326"  # and is not WGS84 (does not need clipping)
-        and (
-            dst_crs.get("init") in CRS_BOUNDS
-            or pyproj.CRS(dst_crs.to_epsg()).area_of_use.bounds
-        )
+        and dst_crs.get("init") in CRS_BOUNDS
     ):
         wgs84_crs = CRS().from_epsg(4326)
         # get dst_crs boundaries
-        crs_bbox = box(
-            *CRS_BOUNDS.get(
-                dst_crs.get("init"), pyproj.CRS(dst_crs.to_epsg()).area_of_use.bounds
-            )
-        )
+        crs_bbox = box(*CRS_BOUNDS.get(dst_crs.get("init")))
         # reproject geometry to WGS84
         geometry_4326 = _reproject_geom(geometry, src_crs, wgs84_crs)
         # raise error if geometry has to be clipped

--- a/mapchete/io/raster.py
+++ b/mapchete/io/raster.py
@@ -298,12 +298,14 @@ def _rasterio_read(
             ),
             resampling=Resampling[resampling],
         ) as vrt:
-            return vrt.read(
-                window=vrt.window(*dst_bounds),
-                out_shape=dst_shape,
-                indexes=indexes,
-                masked=True,
-            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                return vrt.read(
+                    window=vrt.window(*dst_bounds),
+                    out_shape=dst_shape,
+                    indexes=indexes,
+                    masked=True,
+                )
 
     if isinstance(input_file, str):
         logger.debug("got file path %s", input_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ lxml>=4.5.0
 matplotlib>=3.2.1
 numpy>=1.16
 oyaml>=0.9
-pyproj
 retry>=0.9.2
 rasterio>=1.0.28
 s3fs==0.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ lxml>=4.5.0
 matplotlib>=3.2.1
 numpy>=1.16
 oyaml>=0.9
+pyproj
 retry>=0.9.2
 rasterio>=1.0.28
 s3fs==0.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ numpy>=1.16
 oyaml>=0.9
 pyproj
 retry>=0.9.2
-rasterio>=1.0.28,<1.2.8
+rasterio>=1.0.28,<1.2.7
 s3fs==0.5.2
 Shapely>=1.7.1
 tilematrix>=0.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ numpy>=1.16
 oyaml>=0.9
 pyproj
 retry>=0.9.2
-rasterio>=1.0.28
+rasterio>=1.0.28,<1.2.8
 s3fs==0.5.2
 Shapely>=1.7.1
 tilematrix>=0.20

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ install_requires = [
     "importlib-resources",
     "numpy>=1.16",
     "oyaml",
-    "pyproj",
     "retry",
     "rasterio>=1.0.28",
     "shapely",

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ install_requires = [
     "importlib-resources",
     "numpy>=1.16",
     "oyaml",
+    "pyproj",
     "retry",
     "rasterio>=1.0.28",
     "shapely",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ install_requires = [
     "oyaml",
     "pyproj",
     "retry",
-    "rasterio>=1.0.28",
+    "rasterio>=1.0.28,<1.2.8",
     "shapely",
     "tilematrix>=0.20",
     "tqdm",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ install_requires = [
     "oyaml",
     "pyproj",
     "retry",
-    "rasterio>=1.0.28,<1.2.8",
+    "rasterio>=1.0.28,<1.2.7",
     "shapely",
     "tilematrix>=0.20",
     "tqdm",


### PR DESCRIPTION
* add `pyproj` to dependencies
* `mapchete.io.vector.reproject_geometry()`:
  * use `pyproj` to determine CRS bounds to clip geometries when reprojecting
  * enable geometry segmentation before geometry is clipped (`segmentize_on_clip=False` and `segmentize_fraction=100` args)
* suppress `rasterio` warnings when reading rasters (too many `rasterio.errors.NodataShadowWarning`s)