### PR TITLE
WIP: Executor memory usage

### DIFF
--- a/mapchete/_core.py
+++ b/mapchete/_core.py
@@ -349,6 +349,7 @@ class Mapchete(object):
         if tile:
             yield _run_on_single_tile(
                 executor=executor,
+                dask_scheduler=dask_scheduler,
                 process=self,
                 tile=self.config.process_pyramid.tile(*tuple(tile)),
             )

--- a/test/test_executor.py
+++ b/test/test_executor.py
@@ -58,7 +58,7 @@ def test_concurrent_futures_processes_executor_cancel_as_completed():
             executor.cancel()
             break
 
-        assert any([future.cancelled() for future in executor.futures])
+        assert any([future.cancelled() for future in executor.running_futures])
 
 
 def test_concurrent_futures_processes_executor_map():
@@ -79,7 +79,7 @@ def test_concurrent_futures_threads_executor_as_completed():
             executor.cancel()
             break
 
-        assert any([future.cancelled() for future in executor.futures])
+        assert any([future.cancelled() for future in executor.running_futures])
 
 
 def test_concurrent_futures_threads_executor_map():
@@ -100,7 +100,7 @@ def test_dask_executor_as_completed():
             executor.cancel()
             break
 
-        assert any([future.cancelled() for future in executor.futures])
+        assert any([future.cancelled() for future in executor.running_futures])
 
 
 def test_concurrent_futures_dask_executor_map():


### PR DESCRIPTION
* let Executor keep track of running futures and remove finished ones to save memory; try to yield finished futures while submitting new tasks to Executor
* also submit single tile tasks to dask if available