### PR TITLE
make dask executor more resilient

### DIFF
--- a/mapchete/_executor.py
+++ b/mapchete/_executor.py
@@ -175,7 +175,10 @@ class _ExecutorBase:
         """
         Release future from cluster explicitly and wrap result around FinishedFuture object.
         """
-        self.running_futures.remove(future)
+        try:
+            self.running_futures.remove(future)
+        except KeyError:  # pragma: no cover
+            pass
         try:
             self.finished_futures.remove(future)
         except KeyError:

--- a/mapchete/_executor.py
+++ b/mapchete/_executor.py
@@ -376,7 +376,7 @@ class DaskExecutor(_ExecutorBase):
                     for future, result in batch:
                         try:
                             yield from self._yield_from_batch(batch)
-                        except JobCancelledError:
+                        except JobCancelledError:  # pragma: no cover
                             return
                     logger.debug(
                         "%s futures still on cluster", len(self.running_futures)
@@ -398,7 +398,7 @@ class DaskExecutor(_ExecutorBase):
                     for future, result in batch:
                         try:
                             yield from self._yield_from_batch(batch)
-                        except JobCancelledError:
+                        except JobCancelledError:  # pragma: no cover
                             return
 
         finally:
@@ -431,7 +431,7 @@ class DaskExecutor(_ExecutorBase):
                 logger.exception(exc)
                 self._retry(future)
 
-    def _retry(self, future):
+    def _retry(self, future):  # pragma: no cover
         logger.debug("retry future %s", future)
         future.retry()
         self.running_futures.add(future)

--- a/mapchete/errors.py
+++ b/mapchete/errors.py
@@ -39,3 +39,7 @@ class GeometryTypeError(TypeError):
 
 class MapcheteIOError(IOError):
     """Raised when mapchete cannot read a file."""
+
+
+class JobCancelledError(Exception):
+    """Raised when Job gets cancelled."""


### PR DESCRIPTION
* use timeouts when calling future.result() or future.exception()
* retry futures failing with timeouts