### PR TITLE
use threaded concurrency on default when calling 'mapchete cp'

### DIFF
--- a/mapchete/cli/default/cp.py
+++ b/mapchete/cli/default/cp.py
@@ -5,6 +5,10 @@ from mapchete import commands
 from mapchete.cli import options
 
 
+def _cb_none_concurrency(ctx, param, value):
+    return None if value == "none" else value
+
+
 @click.command(help="Copy TileDirectory from one source to another.")
 @options.arg_src_tiledir
 @options.arg_dst_tiledir
@@ -22,7 +26,13 @@ from mapchete.cli import options
 @options.opt_logfile
 @options.opt_workers
 @options.opt_dask_scheduler
-@options.opt_concurrency
+@click.option(
+    "--concurrency",
+    type=click.Choice(["processes", "threads", "dask", "none"]),
+    default="threads",
+    callback=_cb_none_concurrency,
+    help="Decide which Executor to use for concurrent processing.",
+)
 @options.opt_http_username
 @options.opt_http_password
 @options.opt_src_fs_opts

--- a/mapchete/cli/default/cp.py
+++ b/mapchete/cli/default/cp.py
@@ -38,7 +38,7 @@ def _cb_none_concurrency(ctx, param, value):
 @options.opt_src_fs_opts
 @options.opt_dst_fs_opts
 def cp(*args, debug=False, no_pbar=False, verbose=False, logfile=None, **kwargs):
-    """Copy TileDirectory."""
+    """Copy TileDirectory in full or a subset from one source to another."""
     # handle deprecated options
     for x in ["password", "username"]:
         if kwargs.get(x):  # pragma: no cover


### PR DESCRIPTION
closes #525 