### PR TITLE
fix copy() of larger files

### DIFF
--- a/mapchete/io/_misc.py
+++ b/mapchete/io/_misc.py
@@ -190,5 +190,6 @@ def copy(src_path, dst_path, src_fs=None, dst_fs=None, overwrite=False):
         src_path.fs.copy(str(src_path), str(dst_path))
     else:
         with src_path.open("rb") as src:
-            with dst_path.open("wb") as dst:
-                dst.write(src.read())
+            content = src.read()
+        with dst_path.open("wb") as dst:
+            dst.write(content)

--- a/mapchete/path.py
+++ b/mapchete/path.py
@@ -17,7 +17,7 @@ from mapchete.io.settings import GDAL_HTTP_OPTS
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_STORAGE_OPTIONS = {"asynchronous": False, "timeout": 5}
+DEFAULT_STORAGE_OPTIONS = {"asynchronous": False, "timeout": None}
 UNALLOWED_S3_KWARGS = ["timeout"]
 UNALLOWED_HTTP_KWARGS = ["username", "password"]
 


### PR DESCRIPTION
* copy(): don't write empty destination file if reading source fails
*  set default timeout to None as it would fail on read operations of larger files