### PR TITLE
enable adding default read parameters to TileDirectory input

### DIFF
--- a/doc/source/process_input.rst
+++ b/doc/source/process_input.rst
@@ -138,6 +138,29 @@ mapchete process. This is very similar to provide a ``.mapchete`` file path but 
 convenience to just refer to the path.
 
 
+**Example:**
+
+.. code-block:: yaml
+
+    input:
+        foo: path_to_tiledirectory
+
+Sometimes it can be beneficial to pass on some default values to a TileDirectory, such
+as the maximum zoom level available. In that case Mapchete knows to read data from this
+zoom level in case a process runs on a higher zoom.
+
+**Example:**
+
+.. code-block:: yaml
+
+    input:
+        foo:
+            format: TileDirectory
+            path: path_to_tiledirectory
+            resampling: bilinear
+            max_zoom: 8  # now data can be read also from e.g. zoom 9 and will be resampled
+
+
 -------------------------
 Additional output formats
 -------------------------

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -818,6 +818,15 @@ def cleantopo_br_mercator(mp_tmpdir):
 
 
 @pytest.fixture
+def cleantopo_read_lower_zoom(mp_tmpdir):
+    """Fixture for cleantopo_read_lower_zoom.mapchete."""
+    with ProcessFixture(
+        TESTDATA_DIR / "cleantopo_read_lower_zoom.mapchete", output_tempdir=mp_tmpdir
+    ) as example:
+        yield example
+
+
+@pytest.fixture
 def geojson(mp_tmpdir):
     """Fixture for geojson.mapchete."""
     with ProcessFixture(

--- a/test/test_formats_tiledir_input.py
+++ b/test/test_formats_tiledir_input.py
@@ -147,6 +147,14 @@ def test_read_reprojected_raster_data(
         )
 
 
+def test_read_raster_data_from_lower_zoom(cleantopo_read_lower_zoom):
+    """Read raster data."""
+    mp = cleantopo_read_lower_zoom.process_mp()
+    with mp.open("file1") as src:
+        assert src._resampling == "bilinear"
+        assert src.read().any()
+
+
 def test_read_from_dir(mp_tmpdir, cleantopo_br, cleantopo_br_tiledir):
     """Read raster data."""
     # prepare data

--- a/test/testdata/cleantopo_read_lower_zoom.mapchete
+++ b/test/testdata/cleantopo_read_lower_zoom.mapchete
@@ -1,0 +1,15 @@
+process: ../example_process.py
+zoom_levels: 5
+pyramid:
+    grid: geodetic
+input:
+    file1:
+        format: TileDirectory
+        path: cleantopo/
+        max_zoom: 1
+        resampling: bilinear
+output:
+    dtype: uint16
+    bands: 1
+    format: GTiff
+    path: tmp/cleantopo_read_zoom2


### PR DESCRIPTION
This PR allows setting default read values to a TileDirectory:

```yaml
input:
    file1:
        format: TileDirectory
        path: cleantopo/
        max_zoom: 1
        resampling: bilinear
```
In that example, a process running on zoom 2 or higher resamples zoom 1 data from the TileDirectory using bilinear resampling.