### PR TITLE
rasterio>=1.4.x reproject array type

### DIFF
--- a/mapchete/io/raster/array.py
+++ b/mapchete/io/raster/array.py
@@ -169,6 +169,9 @@ def resample_from_array(
 
     dst_data = np.empty(dst_shape, array.dtype)
 
+    if isinstance(array, ma.MaskedArray):
+        array = array.data
+
     reproject(
         array,
         dst_data,

--- a/test/test_io_raster.py
+++ b/test/test_io_raster.py
@@ -409,17 +409,13 @@ def test_resample_from_array():
     # not keep 2D
     in_data = (np.ones(in_tile.shape[1:]),)
     out_tile = BufferedTilePyramid("geodetic").tile(6, 10, 10)
-    out_array = resample_from_array(in_data, in_tile.affine, out_tile, keep_2d=False)   
+    out_array = resample_from_array(in_data, in_tile.affine, out_tile, keep_2d=False)
     assert out_array.shape == (1, 256, 256)
     # Test ma.MaskedArray input
-    in_data = (
-        ma.MaskedArray(
-            data=np.ones(in_tile.shape[1:])
-        ),
-    )
+    in_data = (ma.MaskedArray(data=np.ones(in_tile.shape[1:])),)
     out_tile = BufferedTilePyramid("geodetic").tile(6, 10, 10)
-    out_array = resample_from_array(in_data, in_tile.affine, out_tile)   
-    assert out_array.shape == (1, 256, 256)    
+    out_array = resample_from_array(in_data, in_tile.affine, out_tile)
+    assert out_array.shape == (1, 256, 256)
     # errors
     with pytest.raises(TypeError):
         in_data = "invalid_type"

--- a/test/test_io_raster.py
+++ b/test/test_io_raster.py
@@ -412,7 +412,12 @@ def test_resample_from_array():
     out_array = resample_from_array(in_data, in_tile.affine, out_tile, keep_2d=False)
     assert out_array.shape == (1, 256, 256)
     # Test ma.MaskedArray input
-    in_data = (ma.MaskedArray(data=np.ones(in_tile.shape[1:])),)
+    in_data = (
+        ma.MaskedArray(
+            data=np.ones(in_tile.shape[1:]),
+            mask=np.invert(np.ones(in_tile.shape[1:]), dtype="bool", casting="unsafe"),
+        ),
+    )
     out_tile = BufferedTilePyramid("geodetic").tile(6, 10, 10)
     out_array = resample_from_array(in_data, in_tile.affine, out_tile)
     assert out_array.shape == (1, 256, 256)

--- a/test/test_io_raster.py
+++ b/test/test_io_raster.py
@@ -401,6 +401,25 @@ def test_resample_from_array():
     out_array = resample_from_array(in_data, in_tile.affine, out_tile)
     # deprecated
     resample_from_array(in_data, in_tile.affine, out_tile, nodata=-9999)
+    # keep 2D
+    in_data = (np.ones(in_tile.shape[1:]),)
+    out_tile = BufferedTilePyramid("geodetic").tile(6, 10, 10)
+    out_array = resample_from_array(in_data, in_tile.affine, out_tile, keep_2d=True)
+    assert out_array.shape == (256, 256)
+    # not keep 2D
+    in_data = (np.ones(in_tile.shape[1:]),)
+    out_tile = BufferedTilePyramid("geodetic").tile(6, 10, 10)
+    out_array = resample_from_array(in_data, in_tile.affine, out_tile, keep_2d=False)   
+    assert out_array.shape == (1, 256, 256)
+    # Test ma.MaskedArray input
+    in_data = (
+        ma.MaskedArray(
+            data=np.ones(in_tile.shape[1:])
+        ),
+    )
+    out_tile = BufferedTilePyramid("geodetic").tile(6, 10, 10)
+    out_array = resample_from_array(in_data, in_tile.affine, out_tile)   
+    assert out_array.shape == (1, 256, 256)    
     # errors
     with pytest.raises(TypeError):
         in_data = "invalid_type"


### PR DESCRIPTION
* maybe this, or try to pass `ma.MaskedArray` to the `rasterio.warp.reproject` but seems to work funky now