### PR TITLE
Fix Content-Type of MemoryFile tiles

### DIFF
--- a/mapchete/cli/default/serve.py
+++ b/mapchete/cli/default/serve.py
@@ -174,7 +174,7 @@ def _valid_tile_response(mp, data):
     out_data, mime_type = mp.config.output.for_web(data)
     logger.debug("create tile response %s", mime_type)
     if isinstance(out_data, MemoryFile):
-        return RangeRequest(out_data).make_response()
+        response = RangeRequest(out_data).make_response()
     elif isinstance(out_data, list):
         response = make_response(jsonify(data))
     else:  # pragma: no cover


### PR DESCRIPTION
The Content-Type header isn't set when out_data is a MemoryFile because of the early return. I don't see why an early return is necessary so I made the branch like the other branches.