### PR TITLE
add retry delay to execute

### DIFF
--- a/mapchete/executor/__init__.py
+++ b/mapchete/executor/__init__.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from mapchete.enums import Concurrency
 from mapchete.executor.base import ExecutorBase
 from mapchete.executor.concurrent_futures import (
@@ -13,30 +11,34 @@ from mapchete.executor.sequential import SequentialExecutor
 __all__ = ["MULTIPROCESSING_DEFAULT_START_METHOD", "MFuture"]
 
 
+def get_executor(
+    *args, concurrency: Concurrency = Concurrency.none, **kwargs
+) -> ExecutorBase:
+    concurrency = (
+        Concurrency.dask
+        if kwargs.get("dask_scheduler") or kwargs.get("dask_client")
+        else concurrency
+    )
+
+    if concurrency == Concurrency.dask:
+        return DaskExecutor(*args, **kwargs)
+
+    elif concurrency in [None, Concurrency.none]:
+        return SequentialExecutor(*args, **kwargs)
+
+    elif concurrency in [Concurrency.processes, Concurrency.threads]:
+        return ConcurrentFuturesExecutor(*args, concurrency=concurrency, **kwargs)
+
+    else:  # pragma: no cover
+        raise ValueError(
+            f"concurrency must be one of None, 'processes', 'threads' or 'dask', not {concurrency}"
+        )
+
+
 class Executor:
     """
     Executor factory for dask and concurrent.futures executor
     """
 
-    def __new__(
-        cls, *args, concurrency: Optional[Concurrency] = None, **kwargs
-    ) -> ExecutorBase:
-        concurrency = (
-            Concurrency.dask
-            if kwargs.get("dask_scheduler") or kwargs.get("dask_client")
-            else concurrency
-        )
-
-        if concurrency == Concurrency.dask:
-            return DaskExecutor(*args, **kwargs)
-
-        elif concurrency in [None, Concurrency.none]:
-            return SequentialExecutor(*args, **kwargs)
-
-        elif concurrency in [Concurrency.processes, Concurrency.threads]:
-            return ConcurrentFuturesExecutor(*args, concurrency=concurrency, **kwargs)
-
-        else:  # pragma: no cover
-            raise ValueError(
-                f"concurrency must be one of None, 'processes', 'threads' or 'dask', not {concurrency}"
-            )
+    def __new__(cls, *args, **kwargs) -> ExecutorBase:
+        return get_executor(*args, **kwargs)

--- a/mapchete/executor/base.py
+++ b/mapchete/executor/base.py
@@ -78,7 +78,7 @@ class ExecutorBase(ABC):
         args: Optional[Tuple] = None,
         kwargs: Optional[Dict[str, Any]] = None,
     ) -> None:
-        if profiler:  # pragma: no cover
+        if profiler:
             self.profilers.append(profiler)
         elif name is not None and decorator is not None:
             self.profilers.append(

--- a/mapchete/executor/base.py
+++ b/mapchete/executor/base.py
@@ -17,6 +17,7 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    TypeVar,
     Union,
 )
 
@@ -220,3 +221,7 @@ def func_partial(
         fkwargs=fkwargs,
         profilers=profilers,
     )
+
+
+# TypeVar for BaseClass or its subclasses
+ExecutorType = TypeVar("ExecutorType", bound=ExecutorBase)

--- a/mapchete/executor/base.py
+++ b/mapchete/executor/base.py
@@ -72,16 +72,14 @@ class ExecutorBase(ABC):
 
     def add_profiler(
         self,
+        profiler: Optional[Profiler] = None,
         name: Optional[str] = None,
         decorator: Optional[Callable] = None,
         args: Optional[Tuple] = None,
         kwargs: Optional[Dict[str, Any]] = None,
-        profiler: Optional[Profiler] = None,
     ) -> None:
         if profiler:  # pragma: no cover
             self.profilers.append(profiler)
-        elif isinstance(name, Profiler):
-            self.profilers.append(name)
         elif name is not None and decorator is not None:
             self.profilers.append(
                 Profiler(

--- a/mapchete/processing/base.py
+++ b/mapchete/processing/base.py
@@ -206,7 +206,7 @@ class Mapchete(object):
     def tasks(
         self,
         zoom: Optional[ZoomLevelsLike] = None,
-        tile: Optional[TileLike] = None,
+        tile: Optional[Union[TileLike, BufferedTile]] = None,
         profilers: Optional[List[Profiler]] = None,
     ) -> Tasks:
         """

--- a/mapchete/settings.py
+++ b/mapchete/settings.py
@@ -81,6 +81,8 @@ class MapcheteOptions(BaseSettings):
     future_timeout: int = 10
     tiles_exist_concurrency: Concurrency = Concurrency.threads
     reproject_geometry_engine: Literal["pyproj", "fiona"] = "pyproj"
+    execute_retries: int = 0
+    execute_delay: float = 0
 
     # read from environment
     model_config = SettingsConfigDict(env_prefix="MAPCHETE_")

--- a/test/executor/test_base.py
+++ b/test/executor/test_base.py
@@ -193,7 +193,7 @@ def test_profiling(executor_fixture, request):
     executor = request.getfixturevalue(executor_fixture)
 
     # add profiler
-    executor.add_profiler("time", measure_time)
+    executor.add_profiler(name="time", decorator=measure_time)
 
     items = list(range(10))
     for future in executor.as_completed(_dummy_process, items):


### PR DESCRIPTION
closes #653 

* `commands.execute.execute()`: add `retry_delay` option
* fix typing smells around executor classes 