### PR TITLE
add GeoTIFF indexes

### DIFF
--- a/mapchete/cli/mapchete/index.py
+++ b/mapchete/cli/mapchete/index.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 @options.opt_shp
 @options.opt_fgb
 @options.opt_vrt
+@options.opt_tif
 @options.opt_txt
 @options.opt_fieldname
 @options.opt_basepath

--- a/mapchete/cli/mapchete/index.py
+++ b/mapchete/cli/mapchete/index.py
@@ -10,6 +10,7 @@ from mapchete import commands
 from mapchete.cli import options
 from mapchete.cli.progress_bar import PBar
 from mapchete.path import MPath
+from mapchete.timer import Timer
 
 # workaround for https://github.com/tqdm/tqdm/issues/481
 tqdm.monitor_interval = 0
@@ -65,13 +66,14 @@ def index(
             )
         kwargs.pop(x)
 
-    with PBar(
-        total=100, desc="tiles", disable=debug or no_pbar, print_messages=verbose
-    ) as pbar:
-        commands.index(
-            MPath(tiledir, storage_options=fs_opts),
-            *args,
-            observers=[pbar],
-            **kwargs,
-        )
-    tqdm.tqdm.write(f"index(es) creation for {str(tiledir)} finished")
+    with Timer() as duration:
+        with PBar(
+            total=100, desc="tiles", disable=debug or no_pbar, print_messages=verbose
+        ) as pbar:
+            commands.index(
+                MPath(tiledir, storage_options=fs_opts),
+                *args,
+                observers=[pbar],
+                **kwargs,
+            )
+    tqdm.tqdm.write(f"index(es) creation for {str(tiledir)} finished in {duration}")

--- a/mapchete/cli/options.py
+++ b/mapchete/cli/options.py
@@ -271,6 +271,7 @@ opt_gpkg = click.option("--gpkg", is_flag=True, help="Write GeoPackage index.")
 opt_shp = click.option("--shp", is_flag=True, help="Write Shapefile index.")
 opt_fgb = click.option("--fgb", is_flag=True, help="Write FlatGeobuf index.")
 opt_vrt = click.option("--vrt", is_flag=True, help="Write VRT file.")
+opt_tif = click.option("--tif", is_flag=True, help="Write GeoTIFF index.")
 opt_txt = click.option(
     "--txt", is_flag=True, help="Write output tile paths to text file."
 )

--- a/mapchete/cli/progress_bar.py
+++ b/mapchete/cli/progress_bar.py
@@ -35,11 +35,14 @@ class PBar(ObserverProtocol):
         **kwargs,
     ):
         if progress:
-            if self._pbar.total is None or self._pbar.total != progress.total:
+            # reset progress bar if needed
+            if progress.total is not None and (
+                self._pbar.total is None or self._pbar.total != progress.total
+            ):
                 self._pbar.reset(progress.total)  # type: ignore
 
             self._pbar.n = progress.current
-            self._pbar.update(n=0)
+            self._pbar.update()
 
         if self.print_messages:
             if task_info:

--- a/mapchete/commands/index.py
+++ b/mapchete/commands/index.py
@@ -25,6 +25,7 @@ def index(
     gpkg: bool = False,
     shp: bool = False,
     fgb: bool = False,
+    tif: bool = False,
     vrt: bool = False,
     txt: bool = False,
     fieldname: Optional[str] = "location",
@@ -45,9 +46,9 @@ def index(
     """
     Create one or more indexes from a TileDirectory.
     """
-    if not any([geojson, gpkg, shp, fgb, txt, vrt]):
+    if not any([geojson, gpkg, shp, fgb, tif, txt, vrt]):
         raise ValueError(
-            """At least one of '--geojson', '--gpkg', '--shp', '--fgb', '--vrt' or '--txt'"""
+            """At least one of '--geojson', '--gpkg', '--shp', '--fgb', '--tif', '--vrt' or '--txt'"""
             """must be provided."""
         )
 
@@ -97,6 +98,7 @@ def index(
             gpkg=gpkg,
             shapefile=shp,
             flatgeobuf=fgb,
+            tif=tif,
             vrt=vrt,
             txt=txt,
             fieldname=fieldname,

--- a/mapchete/commands/index.py
+++ b/mapchete/commands/index.py
@@ -12,7 +12,7 @@ from mapchete.commands.parser import InputInfo
 from mapchete.config import MapcheteConfig
 from mapchete.config.parse import bounds_from_opts, raw_conf
 from mapchete.enums import InputType
-from mapchete.index import zoom_index_gen
+from mapchete.index import create_indexes
 from mapchete.types import MPathLike, Progress
 
 logger = logging.getLogger(__name__)
@@ -88,24 +88,19 @@ def index(
     ) as mp:
         total = 1 if tile else mp.count_tiles()
         all_observers.notify(progress=Progress(total=total))
-        for ii, tile in enumerate(
-            zoom_index_gen(
-                config=mp.config,
-                zoom=None if tile else mp.config.init_zoom_levels,
-                tile=tile,
-                out_dir=idx_out_dir if idx_out_dir else mp.config.output.path,
-                geojson=geojson,
-                gpkg=gpkg,
-                shapefile=shp,
-                flatgeobuf=fgb,
-                vrt=vrt,
-                txt=txt,
-                fieldname=fieldname,
-                basepath=basepath,
-                for_gdal=for_gdal,
-            ),
-            1,
-        ):
-            all_observers.notify(
-                progress=Progress(current=ii, total=total), message=f"{tile.id} indexed"
-            )
+        create_indexes(
+            config=mp.config,
+            zoom=None if tile else mp.config.init_zoom_levels,
+            tile=tile,
+            out_dir=idx_out_dir if idx_out_dir else mp.config.output.path,
+            geojson=geojson,
+            gpkg=gpkg,
+            shapefile=shp,
+            flatgeobuf=fgb,
+            vrt=vrt,
+            txt=txt,
+            fieldname=fieldname,
+            basepath=basepath,
+            for_gdal=for_gdal,
+            observers=all_observers.observers,
+        )

--- a/mapchete/commands/index.py
+++ b/mapchete/commands/index.py
@@ -90,7 +90,7 @@ def index(
         all_observers.notify(progress=Progress(total=total))
         for ii, tile in enumerate(
             zoom_index_gen(
-                mp=mp,
+                config=mp.config,
                 zoom=None if tile else mp.config.init_zoom_levels,
                 tile=tile,
                 out_dir=idx_out_dir if idx_out_dir else mp.config.output.path,

--- a/mapchete/index.py
+++ b/mapchete/index.py
@@ -565,7 +565,7 @@ class RasterFileWriter:
             self.array = np.zeros(shape, dtype=bool)
         self.existing_entries = self.array.sum()
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         return "RasterFileWriter(%s)" % self.path
 
     def __enter__(self):
@@ -579,6 +579,7 @@ class RasterFileWriter:
             **self.profile,
         ) as dst:
             dst.write(self.array, 1)
+        self.close()
 
     def write(
         self, tile: Optional[BufferedTile] = None, path: Optional[MPathLike] = None
@@ -588,7 +589,7 @@ class RasterFileWriter:
             self.array[tile.row][tile.col] = True
 
     def entry_exists(self, tile: Optional[BufferedTile] = None, **_) -> bool:
-        if tile is None:
+        if tile is None:  # pragma: no cover
             raise ValueError("tile must be provided")
         exists = bool(self.array[tile.row][tile.col])
         logger.debug("%s exists: %s", tile, exists)

--- a/mapchete/index.py
+++ b/mapchete/index.py
@@ -28,6 +28,7 @@ from typing import Optional, Any, List
 from xml.dom import minidom
 
 import fiona
+import numpy as np
 from rasterio.dtypes import _gdal_typename
 from shapely.geometry import mapping
 
@@ -39,13 +40,16 @@ from mapchete.io import (
     fs_from_path,
     path_exists,
     raster,
+    rasterio_open,
     relative_path,
     tiles_exist,
     vector,
 )
+from mapchete.io.profiles import COGDeflateProfile
+from mapchete.io.raster import ReferencedRaster
 from mapchete.commands.observer import ObserverProtocol, Observers
 from mapchete.path import batch_sort_property
-from mapchete.tile import BufferedTile, BufferedTilePyramid
+from mapchete.tile import BufferedTile, BufferedTilePyramid, Shape
 from mapchete.types import ZoomLevelsLike, TileLike, MPathLike, CRSLike, Progress
 
 logger = logging.getLogger(__name__)
@@ -131,6 +135,16 @@ def create_indexes(
                         )
                     )
                 )
+            if tif:
+                index_writers.append(
+                    es.enter_context(
+                        RasterFileWriter(
+                            out_path=_index_file_path(out_dir, zoom, "tif"),
+                            out_pyramid=config.output_pyramid,
+                            zoom=zoom,
+                        )
+                    )
+                )
             if txt:
                 index_writers.append(
                     es.enter_context(
@@ -164,6 +178,7 @@ def create_indexes(
                     exact=True,
                 )
 
+            # TODO: make function to quickly return only existing tiles
             for output_tile, exists in tiles_exist(
                 config, output_tiles_batches=output_tiles_batches
             ):
@@ -518,3 +533,67 @@ class VRTFileWriter:
         logger.debug("write to %s", self.path)
         with self.fs.open(self.path, "w") as dst:
             dst.write(xmlstr)
+
+
+class RasterFileWriter:
+    """Writes raster files."""
+
+    array: np.ndarray
+
+    def __init__(
+        self,
+        out_path: MPathLike,
+        out_pyramid: BufferedTilePyramid,
+        zoom: int,
+    ):
+        self.path = MPath.from_inp(out_path)
+        self.pyramid = out_pyramid.without_pixelbuffer()
+        self.zoom = zoom
+        shape = Shape(self.pyramid.matrix_height(zoom), self.pyramid.matrix_width(zoom))
+        self.profile = COGDeflateProfile(
+            count=1,
+            nodata=0,
+            crs=out_pyramid.crs,
+            width=shape.width,
+            height=shape.height,
+            transform=self.pyramid.matrix_affine(zoom),
+            dtype=np.uint8,
+        )
+        try:
+            self.array = ReferencedRaster.from_file(self.path).array.data.astype(bool)
+        except FileNotFoundError:
+            self.array = np.zeros(shape, dtype=bool)
+        self.existing_entries = self.array.sum()
+
+    def __repr__(self):
+        return "RasterFileWriter(%s)" % self.path
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        # TODO: reload existing file in case it was changed while this index was updated
+        with rasterio_open(
+            self.path,
+            "w",
+            **self.profile,
+        ) as dst:
+            dst.write(self.array, 1)
+
+    def write(
+        self, tile: Optional[BufferedTile] = None, path: Optional[MPathLike] = None
+    ):
+        if not self.entry_exists(tile=tile):
+            logger.debug("write %s to %s", path, self)
+            self.array[tile.row][tile.col] = True
+
+    def entry_exists(self, tile: Optional[BufferedTile] = None, **_) -> bool:
+        if tile is None:
+            raise ValueError("tile must be provided")
+        exists = bool(self.array[tile.row][tile.col])
+        logger.debug("%s exists: %s", tile, exists)
+        return exists
+
+    def close(self):
+        new_entries = self.array.sum() - self.existing_entries
+        logger.debug("%s new entries in %s", new_entries, self)

--- a/mapchete/index.py
+++ b/mapchete/index.py
@@ -24,12 +24,14 @@ import operator
 import xml.etree.ElementTree as ET
 from contextlib import ExitStack
 from copy import deepcopy
+from typing import Optional, Generator
 from xml.dom import minidom
 
 import fiona
 from rasterio.dtypes import _gdal_typename
 from shapely.geometry import mapping
 
+from mapchete.config import MapcheteConfig
 from mapchete.config.parse import get_zoom_levels
 from mapchete.io import (
     MPath,
@@ -42,6 +44,8 @@ from mapchete.io import (
     vector,
 )
 from mapchete.path import batch_sort_property
+from mapchete.tile import BufferedTile
+from mapchete.types import ZoomLevelsLike, TileLike, MPathLike, CRSLike
 
 logger = logging.getLogger(__name__)
 
@@ -52,20 +56,20 @@ spatial_schema = {
 
 
 def zoom_index_gen(
-    mp=None,
-    out_dir=None,
-    zoom=None,
-    tile=None,
-    geojson=False,
-    gpkg=False,
-    shapefile=False,
-    flatgeobuf=False,
-    txt=False,
-    vrt=False,
-    fieldname="location",
-    basepath=None,
-    for_gdal=True,
-):
+    config: MapcheteConfig,
+    out_dir: MPath,
+    zoom: Optional[ZoomLevelsLike] = None,
+    tile: Optional[TileLike] = None,
+    geojson: bool = False,
+    gpkg: bool = False,
+    shapefile: bool = False,
+    flatgeobuf: bool = False,
+    txt: bool = False,
+    vrt: bool = False,
+    fieldname: str = "location",
+    basepath: Optional[MPathLike] = None,
+    for_gdal: bool = True,
+) -> Generator[BufferedTile, None, None]:
     """
     Generate indexes for given zoom level.
     """
@@ -83,7 +87,7 @@ def zoom_index_gen(
                         VectorFileWriter(
                             driver="GeoJSON",
                             out_path=_index_file_path(out_dir, zoom, "geojson"),
-                            crs=mp.config.output_pyramid.crs,
+                            crs=config.output_pyramid.crs,
                             fieldname=fieldname,
                         )
                     )
@@ -94,7 +98,7 @@ def zoom_index_gen(
                         VectorFileWriter(
                             driver="GPKG",
                             out_path=_index_file_path(out_dir, zoom, "gpkg"),
-                            crs=mp.config.output_pyramid.crs,
+                            crs=config.output_pyramid.crs,
                             fieldname=fieldname,
                         )
                     )
@@ -105,7 +109,7 @@ def zoom_index_gen(
                         VectorFileWriter(
                             driver="ESRI Shapefile",
                             out_path=_index_file_path(out_dir, zoom, "shp"),
-                            crs=mp.config.output_pyramid.crs,
+                            crs=config.output_pyramid.crs,
                             fieldname=fieldname,
                         )
                     )
@@ -116,7 +120,7 @@ def zoom_index_gen(
                         VectorFileWriter(
                             driver="FlatGeobuf",
                             out_path=_index_file_path(out_dir, zoom, "fgb"),
-                            crs=mp.config.output_pyramid.crs,
+                            crs=config.output_pyramid.crs,
                             fieldname=fieldname,
                         )
                     )
@@ -132,8 +136,8 @@ def zoom_index_gen(
                     es.enter_context(
                         VRTFileWriter(
                             out_path=_index_file_path(out_dir, zoom, "vrt"),
-                            output=mp.config.output,
-                            out_pyramid=mp.config.output_pyramid,
+                            output=config.output,
+                            out_pyramid=config.output_pyramid,
                         )
                     )
                 )
@@ -141,30 +145,24 @@ def zoom_index_gen(
             logger.debug("use the following index writers: %s", index_writers)
 
             if tile:
-                output_tiles_batches = (
-                    mp.config.output_pyramid.tiles_from_bounds_batches(
-                        mp.config.process_pyramid.tile(*tile).bounds,
-                        zoom,
-                        batch_by=batch_sort_property(
-                            mp.config.output_reader.tile_path_schema
-                        ),
-                    )
+                output_tiles_batches = config.output_pyramid.tiles_from_bounds_batches(
+                    config.process_pyramid.tile(*tile).bounds,
+                    zoom,
+                    batch_by=batch_sort_property(config.output_reader.tile_path_schema),
                 )
             else:
-                output_tiles_batches = mp.config.output_pyramid.tiles_from_geom_batches(
-                    mp.config.area_at_zoom(zoom),
+                output_tiles_batches = config.output_pyramid.tiles_from_geom_batches(
+                    config.area_at_zoom(zoom),
                     zoom,
-                    batch_by=batch_sort_property(
-                        mp.config.output_reader.tile_path_schema
-                    ),
+                    batch_by=batch_sort_property(config.output_reader.tile_path_schema),
                     exact=True,
                 )
 
             for output_tile, exists in tiles_exist(
-                mp.config, output_tiles_batches=output_tiles_batches
+                config, output_tiles_batches=output_tiles_batches
             ):
                 tile_path = _tile_path(
-                    orig_path=mp.config.output.get_path(output_tile),
+                    orig_path=config.output.get_path(output_tile),
                     basepath=basepath,
                     for_gdal=for_gdal,
                 )
@@ -185,11 +183,13 @@ def zoom_index_gen(
                 yield output_tile
 
 
-def _index_file_path(out_dir, zoom, ext):
+def _index_file_path(out_dir: MPathLike, zoom: int, ext: str) -> MPath:
     return MPath.from_inp(out_dir) / f"{str(zoom)}.{ext}"
 
 
-def _tile_path(orig_path=None, basepath=None, for_gdal=True):
+def _tile_path(
+    orig_path: MPathLike, basepath: Optional[MPathLike] = None, for_gdal: bool = True
+) -> str:
     path = (
         MPath.from_inp(basepath).joinpath(*orig_path.elements[-3:])
         if basepath
@@ -204,7 +204,7 @@ def _tile_path(orig_path=None, basepath=None, for_gdal=True):
 class VectorFileWriter:
     """Writes GeoJSON or GeoPackage files."""
 
-    def __init__(self, out_path=None, crs=None, fieldname=None, driver=None):
+    def __init__(self, out_path: MPathLike, crs: CRSLike, fieldname: str, driver: str):
         self.path = MPath.from_inp(out_path)
         self._append = (
             "a" in fiona.supported_drivers[driver] and not self.path.is_remote()
@@ -266,7 +266,7 @@ class VectorFileWriter:
         finally:
             self.close()
 
-    def write(self, tile, path):
+    def write(self, tile: TileLike, path: MPathLike) -> None:
         if not self.entry_exists(tile=tile):
             logger.debug("write %s to %s", path, self)
             self.sink.write(
@@ -283,7 +283,7 @@ class VectorFileWriter:
             )
             self.new_entries += 1
 
-    def entry_exists(self, tile=None, path=None):
+    def entry_exists(self, tile: TileLike, path=None):
         exists = str(tile.id) in self._existing.keys()
         logger.debug("%s exists: %s", tile, exists)
         return exists

--- a/mapchete/index.py
+++ b/mapchete/index.py
@@ -545,25 +545,26 @@ class RasterFileWriter:
         out_path: MPathLike,
         out_pyramid: BufferedTilePyramid,
         zoom: int,
+        reload_before_write: bool = False,
     ):
         self.path = MPath.from_inp(out_path)
         self.pyramid = out_pyramid.without_pixelbuffer()
         self.zoom = zoom
-        shape = Shape(self.pyramid.matrix_height(zoom), self.pyramid.matrix_width(zoom))
+        self.shape = Shape(
+            self.pyramid.matrix_height(zoom), self.pyramid.matrix_width(zoom)
+        )
         self.profile = COGDeflateProfile(
             count=1,
             nodata=0,
             crs=out_pyramid.crs,
-            width=shape.width,
-            height=shape.height,
+            width=self.shape.width,
+            height=self.shape.height,
             transform=self.pyramid.matrix_affine(zoom),
             dtype=np.uint8,
         )
-        try:
-            self.array = ReferencedRaster.from_file(self.path).array.data.astype(bool)
-        except FileNotFoundError:
-            self.array = np.zeros(shape, dtype=bool)
+        self.array = self.existing_or_empty_array()
         self.existing_entries = self.array.sum()
+        self.reload_before_write = reload_before_write
 
     def __repr__(self):  # pragma: no cover
         return "RasterFileWriter(%s)" % self.path
@@ -572,14 +573,13 @@ class RasterFileWriter:
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
-        # TODO: reload existing file in case it was changed while this index was updated
-        with rasterio_open(
-            self.path,
-            "w",
-            **self.profile,
-        ) as dst:
-            dst.write(self.array, 1)
         self.close()
+
+    def existing_or_empty_array(self) -> np.ndarray:
+        try:
+            return ReferencedRaster.from_file(self.path).array.data.astype(bool)
+        except FileNotFoundError:
+            return np.zeros(self.shape, dtype=bool)
 
     def write(
         self, tile: Optional[BufferedTile] = None, path: Optional[MPathLike] = None
@@ -598,3 +598,15 @@ class RasterFileWriter:
     def close(self):
         new_entries = self.array.sum() - self.existing_entries
         logger.debug("%s new entries in %s", new_entries, self)
+        if self.reload_before_write:
+            # reload existing file in case it was changed while this index was updated
+            array = self.array + self.existing_or_empty_array()
+        else:
+            array = self.array
+        # write
+        with rasterio_open(
+            self.path,
+            "w",
+            **self.profile,
+        ) as dst:
+            dst.write(array, 1)

--- a/mapchete/index.py
+++ b/mapchete/index.py
@@ -138,7 +138,7 @@ def create_indexes(
             if tif:
                 index_writers.append(
                     es.enter_context(
-                        RasterFileWriter(
+                        RasterIndexWriter(
                             out_path=_index_file_path(out_dir, zoom, "tif"),
                             out_pyramid=config.output_pyramid,
                             zoom=zoom,
@@ -535,7 +535,7 @@ class VRTFileWriter:
             dst.write(xmlstr)
 
 
-class RasterFileWriter:
+class RasterIndexWriter:
     """Writes raster files."""
 
     array: np.ndarray
@@ -562,7 +562,7 @@ class RasterFileWriter:
             transform=self.pyramid.matrix_affine(zoom),
             dtype=np.uint8,
         )
-        self.array = self.existing_or_empty_array()
+        self.array = self.reload()
         self.existing_entries = self.array.sum()
         self.reload_before_write = reload_before_write
 
@@ -573,13 +573,22 @@ class RasterFileWriter:
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
-        self.close()
+        self.dump(self.reload_before_write)
 
-    def existing_or_empty_array(self) -> np.ndarray:
+    def reload(self) -> np.ndarray:
+        """Reloads existing index if it exists and combines it with current array."""
         try:
-            return ReferencedRaster.from_file(self.path).array.data.astype(bool)
+            existing = ReferencedRaster.from_file(self.path).array.data.astype(bool)[0]
         except FileNotFoundError:
-            return np.zeros(self.shape, dtype=bool)
+            existing = np.zeros(self.shape, dtype=bool)
+
+        try:
+            self.array += existing
+        except AttributeError:
+            # if self.array hasn't been set yet, an AttributeError is being thrown
+            self.array = existing
+
+        return self.array
 
     def write(
         self, tile: Optional[BufferedTile] = None, path: Optional[MPathLike] = None
@@ -595,18 +604,18 @@ class RasterFileWriter:
         logger.debug("%s exists: %s", tile, exists)
         return exists
 
-    def close(self):
+    def dump(self, reload_before_write: bool = False):
+        # reload existing file in case it was changed while this index was updated
+        if reload_before_write or self.reload_before_write:
+            self.reload()
+
         new_entries = self.array.sum() - self.existing_entries
         logger.debug("%s new entries in %s", new_entries, self)
-        if self.reload_before_write:
-            # reload existing file in case it was changed while this index was updated
-            array = self.array + self.existing_or_empty_array()
-        else:
-            array = self.array
+
         # write
         with rasterio_open(
             self.path,
             "w",
             **self.profile,
         ) as dst:
-            dst.write(array, 1)
+            dst.write(self.array, 1)

--- a/mapchete/index.py
+++ b/mapchete/index.py
@@ -67,6 +67,7 @@ def create_indexes(
     flatgeobuf: bool = False,
     txt: bool = False,
     vrt: bool = False,
+    tif: bool = False,
     fieldname: str = "location",
     basepath: Optional[MPathLike] = None,
     for_gdal: bool = True,
@@ -81,7 +82,7 @@ def create_indexes(
     all_observers = Observers(observers)
 
     zoom = tile.zoom if tile else zoom
-    ii = 0
+    count = 0
     for zoom in get_zoom_levels(process_zoom_levels=zoom):
         with ExitStack() as es:
             # get index writers for all enabled formats
@@ -184,9 +185,10 @@ def create_indexes(
                     for index in indexes:
                         index.write(output_tile, tile_path)
 
-                ii += 1
+                count += 1
                 all_observers.notify(
-                    progress=Progress(current=ii), message=f"{output_tile.id} indexed"
+                    progress=Progress(current=count),
+                    message=f"{output_tile.id} indexed",
                 )
 
 

--- a/mapchete/index.py
+++ b/mapchete/index.py
@@ -578,6 +578,7 @@ class RasterIndexWriter:
     def reload(self) -> np.ndarray:
         """Reloads existing index if it exists and combines it with current array."""
         try:
+            self.path.wait_for_lock()
             existing = ReferencedRaster.from_file(self.path).array.data.astype(bool)[0]
         except FileNotFoundError:
             existing = np.zeros(self.shape, dtype=bool)
@@ -609,13 +610,13 @@ class RasterIndexWriter:
         if reload_before_write or self.reload_before_write:
             self.reload()
 
-        new_entries = self.array.sum() - self.existing_entries
-        logger.debug("%s new entries in %s", new_entries, self)
-
-        # write
-        with rasterio_open(
-            self.path,
-            "w",
-            **self.profile,
-        ) as dst:
-            dst.write(self.array, 1)
+        with self.path.lock():
+            new_entries = self.array.sum() - self.existing_entries
+            logger.debug("%s new entries in %s", new_entries, self)
+            # write
+            with rasterio_open(
+                self.path,
+                "w",
+                **self.profile,
+            ) as dst:
+                dst.write(self.array, 1)

--- a/mapchete/index.py
+++ b/mapchete/index.py
@@ -24,7 +24,7 @@ import operator
 import xml.etree.ElementTree as ET
 from contextlib import ExitStack
 from copy import deepcopy
-from typing import Optional, Generator
+from typing import Optional, Any, List
 from xml.dom import minidom
 
 import fiona
@@ -43,9 +43,10 @@ from mapchete.io import (
     tiles_exist,
     vector,
 )
+from mapchete.commands.observer import ObserverProtocol, Observers
 from mapchete.path import batch_sort_property
-from mapchete.tile import BufferedTile
-from mapchete.types import ZoomLevelsLike, TileLike, MPathLike, CRSLike
+from mapchete.tile import BufferedTile, BufferedTilePyramid
+from mapchete.types import ZoomLevelsLike, TileLike, MPathLike, CRSLike, Progress
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +56,7 @@ spatial_schema = {
 }
 
 
-def zoom_index_gen(
+def create_indexes(
     config: MapcheteConfig,
     out_dir: MPath,
     zoom: Optional[ZoomLevelsLike] = None,
@@ -69,14 +70,18 @@ def zoom_index_gen(
     fieldname: str = "location",
     basepath: Optional[MPathLike] = None,
     for_gdal: bool = True,
-) -> Generator[BufferedTile, None, None]:
+    observers: Optional[List[ObserverProtocol]] = None,
+) -> None:
     """
     Generate indexes for given zoom level.
     """
     if tile and zoom:  # pragma: no cover
         raise ValueError("tile and zoom cannot be used at the same time")
 
+    all_observers = Observers(observers)
+
     zoom = tile.zoom if tile else zoom
+    ii = 0
     for zoom in get_zoom_levels(process_zoom_levels=zoom):
         with ExitStack() as es:
             # get index writers for all enabled formats
@@ -179,8 +184,10 @@ def zoom_index_gen(
                     for index in indexes:
                         index.write(output_tile, tile_path)
 
-                # yield tile for progress information
-                yield output_tile
+                ii += 1
+                all_observers.notify(
+                    progress=Progress(current=ii), message=f"{output_tile.id} indexed"
+                )
 
 
 def _index_file_path(out_dir: MPathLike, zoom: int, ext: str) -> MPath:
@@ -266,7 +273,9 @@ class VectorFileWriter:
         finally:
             self.close()
 
-    def write(self, tile: TileLike, path: MPathLike) -> None:
+    def write(
+        self, tile: Optional[BufferedTile] = None, path: Optional[MPathLike] = None
+    ):
         if not self.entry_exists(tile=tile):
             logger.debug("write %s to %s", path, self)
             self.sink.write(
@@ -283,7 +292,9 @@ class VectorFileWriter:
             )
             self.new_entries += 1
 
-    def entry_exists(self, tile: TileLike, path=None):
+    def entry_exists(
+        self, tile: Optional[BufferedTile] = None, path: Optional[MPathLike] = None
+    ) -> bool:
         exists = str(tile.id) in self._existing.keys()
         logger.debug("%s exists: %s", tile, exists)
         return exists
@@ -296,7 +307,7 @@ class VectorFileWriter:
 class TextFileWriter:
     """Writes tile paths into text file."""
 
-    def __init__(self, out_path=None):
+    def __init__(self, out_path: MPathLike):
         self.path = out_path
         logger.debug("initialize TXT writer")
         self.fs = fs_from_path(out_path)
@@ -310,7 +321,7 @@ class TextFileWriter:
         for line in self._existing:
             self._write_line(line)
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         return "TextFileWriter(%s)" % self.path
 
     def __enter__(self):
@@ -322,13 +333,17 @@ class TextFileWriter:
     def _write_line(self, line):
         self.sink.write(line)
 
-    def write(self, tile, path):
+    def write(
+        self, tile: Optional[BufferedTile] = None, path: Optional[MPathLike] = None
+    ):
         if not self.entry_exists(path=path):
             logger.debug("write %s to %s", path, self)
             self._write_line(path + "\n")
             self.new_entries += 1
 
-    def entry_exists(self, tile=None, path=None):
+    def entry_exists(
+        self, tile: Optional[BufferedTile] = None, path: Optional[MPathLike] = None
+    ) -> bool:
         exists = path + "\n" in self._existing
         logger.debug("tile %s with path %s exists: %s", tile, path, exists)
         return exists
@@ -341,7 +356,9 @@ class TextFileWriter:
 class VRTFileWriter:
     """Generates GDAL-style VRT file."""
 
-    def __init__(self, out_path=None, output=None, out_pyramid=None):
+    def __init__(
+        self, out_path: MPathLike, output: Any, out_pyramid: BufferedTilePyramid
+    ):
         # see if lxml is installed before checking all output tiles
 
         self.path = out_path
@@ -384,13 +401,17 @@ class VRTFileWriter:
             path = next(entry.iter("SourceFilename")).text
             yield (self._path_to_tile(path), path)
 
-    def write(self, tile, path):
+    def write(
+        self, tile: Optional[BufferedTile] = None, path: Optional[MPathLike] = None
+    ):
         if not self.entry_exists(tile=tile, path=path):
             logger.debug("write %s to %s", path, self)
             self._add_entry(tile=tile, path=path)
             self.new_entries += 1
 
-    def entry_exists(self, tile=None, path=None):
+    def entry_exists(
+        self, tile: Optional[BufferedTile] = None, path: Optional[MPathLike] = None
+    ) -> bool:
         path = relative_path(path=path, base_dir=self.path.dirname)
         exists = path in self._existing
         logger.debug("tile %s with path %s exists: %s", tile, path, exists)

--- a/mapchete/index.py
+++ b/mapchete/index.py
@@ -41,6 +41,7 @@ from mapchete.io import (
     rasterio_open,
     relative_path,
     tiles_exist,
+    all_existing_output_tiles,
     vector,
 )
 from mapchete.io.profiles import COGDeflateProfile
@@ -162,47 +163,90 @@ def create_indexes(
 
             logger.debug("use the following index writers: %s", index_writers)
 
-            if tile:
-                output_tiles_batches = config.output_pyramid.tiles_from_bounds_batches(
-                    config.process_pyramid.tile(*tile).bounds,
-                    zoom,
-                    batch_by=batch_sort_property(config.output_reader.tile_path_schema),
-                )
+            # global search
+            if tile is None and config.output.pyramid.bounds == config.init_bounds:
+                logger.debug("using quicker global index creation")
+                all_observers.notify(progress=Progress(total=None))
+                for output_tile in all_existing_output_tiles(config, zoom):
+                    tile_path = _tile_path(
+                        orig_path=config.output.get_path(output_tile),
+                        basepath=basepath,
+                        for_gdal=for_gdal,
+                    )
+                    # get indexes where tile entry does not exist
+                    indexes = [
+                        index_writer
+                        for index_writer in index_writers
+                        if not index_writer.entry_exists(
+                            tile=output_tile, path=tile_path
+                        )
+                    ]
+
+                    if indexes:
+                        logger.debug("%s exists", tile_path)
+                        logger.debug("write to %s indexes", len(indexes))
+                        for index in indexes:
+                            index.write(output_tile, tile_path)
+
+                    count += 1
+                    all_observers.notify(
+                        progress=Progress(current=count),
+                        message=f"{output_tile.id} indexed",
+                    )
+
+            # spatial subset search
             else:
-                output_tiles_batches = config.output_pyramid.tiles_from_geom_batches(
-                    config.area_at_zoom(zoom),
-                    zoom,
-                    batch_by=batch_sort_property(config.output_reader.tile_path_schema),
-                    exact=True,
-                )
+                if tile:
+                    output_tiles_batches = (
+                        config.output_pyramid.tiles_from_bounds_batches(
+                            config.process_pyramid.tile(*tile).bounds,
+                            zoom,
+                            batch_by=batch_sort_property(
+                                config.output_reader.tile_path_schema
+                            ),
+                        )
+                    )
+                else:
+                    output_tiles_batches = (
+                        config.output_pyramid.tiles_from_geom_batches(
+                            config.area_at_zoom(zoom),
+                            zoom,
+                            batch_by=batch_sort_property(
+                                config.output_reader.tile_path_schema
+                            ),
+                            exact=True,
+                        )
+                    )
 
-            # TODO: make function to quickly return only existing tiles
-            for output_tile, exists in tiles_exist(
-                config, output_tiles_batches=output_tiles_batches
-            ):
-                tile_path = _tile_path(
-                    orig_path=config.output.get_path(output_tile),
-                    basepath=basepath,
-                    for_gdal=for_gdal,
-                )
-                # get indexes where tile entry does not exist
-                indexes = [
-                    index_writer
-                    for index_writer in index_writers
-                    if not index_writer.entry_exists(tile=output_tile, path=tile_path)
-                ]
+                # TODO: make function to quickly return only existing tiles
+                for output_tile, exists in tiles_exist(
+                    config, output_tiles_batches=output_tiles_batches
+                ):
+                    tile_path = _tile_path(
+                        orig_path=config.output.get_path(output_tile),
+                        basepath=basepath,
+                        for_gdal=for_gdal,
+                    )
+                    # get indexes where tile entry does not exist
+                    indexes = [
+                        index_writer
+                        for index_writer in index_writers
+                        if not index_writer.entry_exists(
+                            tile=output_tile, path=tile_path
+                        )
+                    ]
 
-                if indexes and exists:
-                    logger.debug("%s exists", tile_path)
-                    logger.debug("write to %s indexes", len(indexes))
-                    for index in indexes:
-                        index.write(output_tile, tile_path)
+                    if indexes and exists:
+                        logger.debug("%s exists", tile_path)
+                        logger.debug("write to %s indexes", len(indexes))
+                        for index in indexes:
+                            index.write(output_tile, tile_path)
 
-                count += 1
-                all_observers.notify(
-                    progress=Progress(current=count),
-                    message=f"{output_tile.id} indexed",
-                )
+                    count += 1
+                    all_observers.notify(
+                        progress=Progress(current=count),
+                        message=f"{output_tile.id} indexed",
+                    )
 
 
 def _index_file_path(out_dir: MPathLike, zoom: int, ext: str) -> MPath:

--- a/mapchete/index.py
+++ b/mapchete/index.py
@@ -164,11 +164,20 @@ def create_indexes(
             logger.debug("use the following index writers: %s", index_writers)
 
             # global search
-            if tile is None and config.output.pyramid.bounds == config.init_bounds:
+            if (
+                # no tile given
+                tile is None
+                and
+                # no subset given
+                config.output.pyramid.bounds == config.init_bounds
+                and
+                # is actually a TilePyramid and not a single file output
+                config.output_reader.path.suffix != config.output_reader.file_extension
+            ):
                 logger.debug("using quicker global index creation")
                 all_observers.notify(progress=Progress(total=None))
                 for output_tile in all_existing_output_tiles(config, zoom):
-                    tile_path = _tile_path(
+                    tile_path = _tile_path_str(
                         orig_path=config.output.get_path(output_tile),
                         basepath=basepath,
                         for_gdal=for_gdal,
@@ -196,8 +205,8 @@ def create_indexes(
 
             # spatial subset search
             else:
-                if tile:
-                    output_tiles_batches = (
+                output_tiles_batches = (
+                    (
                         config.output_pyramid.tiles_from_bounds_batches(
                             config.process_pyramid.tile(*tile).bounds,
                             zoom,
@@ -206,8 +215,8 @@ def create_indexes(
                             ),
                         )
                     )
-                else:
-                    output_tiles_batches = (
+                    if tile
+                    else (
                         config.output_pyramid.tiles_from_geom_batches(
                             config.area_at_zoom(zoom),
                             zoom,
@@ -217,12 +226,12 @@ def create_indexes(
                             exact=True,
                         )
                     )
+                )
 
-                # TODO: make function to quickly return only existing tiles
                 for output_tile, exists in tiles_exist(
                     config, output_tiles_batches=output_tiles_batches
                 ):
-                    tile_path = _tile_path(
+                    tile_path = _tile_path_str(
                         orig_path=config.output.get_path(output_tile),
                         basepath=basepath,
                         for_gdal=for_gdal,
@@ -253,7 +262,7 @@ def _index_file_path(out_dir: MPathLike, zoom: int, ext: str) -> MPath:
     return MPath.from_inp(out_dir) / f"{str(zoom)}.{ext}"
 
 
-def _tile_path(
+def _tile_path_str(
     orig_path: MPathLike, basepath: Optional[MPathLike] = None, for_gdal: bool = True
 ) -> str:
     path = (
@@ -514,7 +523,7 @@ class VRTFileWriter:
                         E.ComplexSource(
                             E.SourceFilename(
                                 (
-                                    _tile_path(orig_path=path, for_gdal=True)
+                                    _tile_path_str(orig_path=path, for_gdal=True)
                                     if path.is_remote()
                                     else str(
                                         path.relative_path(start=self.path.dirname)

--- a/mapchete/index.py
+++ b/mapchete/index.py
@@ -47,7 +47,7 @@ from mapchete.io import (
 from mapchete.io.profiles import COGDeflateProfile
 from mapchete.io.raster import ReferencedRaster
 from mapchete.commands.observer import ObserverProtocol, Observers
-from mapchete.path import batch_sort_property
+from mapchete.path import batch_sort_property, path_to_tile
 from mapchete.tile import BufferedTile, BufferedTilePyramid, Shape
 from mapchete.types import ZoomLevelsLike, TileLike, MPathLike, CRSLike, Progress
 
@@ -417,6 +417,7 @@ class VRTFileWriter:
     """Generates GDAL-style VRT file."""
 
     path: MPath
+    tile_path_schema: str
 
     def __init__(
         self, out_path: MPathLike, output: Any, out_pyramid: BufferedTilePyramid
@@ -424,8 +425,11 @@ class VRTFileWriter:
         # see if lxml is installed before checking all output tiles
 
         self.path = MPath.from_inp(out_path)
-        self._tp = out_pyramid
+        self.pyramid = out_pyramid
         self._output = output
+        self.tile_path_schema = getattr(
+            output, "tile_path_schema", "{zoom}/{row}/{col}.{extension}"
+        )
         logger.debug("initialize VRT writer for %s", self.path)
         if self.path.exists():
             with self.path.open() as src:
@@ -447,11 +451,6 @@ class VRTFileWriter:
     def __exit__(self, *args):
         self.close()
 
-    def _path_to_tile(self, path):
-        return self._tp.tile(
-            *map(int, MPath.from_inp(path).without_suffix().elements[-3:])
-        )
-
     def _add_entry(self, tile=None, path=None):
         self._new[tile] = MPath.from_inp(path)
 
@@ -460,7 +459,14 @@ class VRTFileWriter:
             ET.ElementTree(ET.fromstring(xml_string)).getroot().iter("VRTRasterBand")
         ).iter("ComplexSource"):
             path = next(entry.iter("SourceFilename")).text
-            yield (self._path_to_tile(path), path)
+            yield (
+                path_to_tile(
+                    MPath.from_inp(path),
+                    pyramid=self.pyramid,
+                    tile_path_schema=self.tile_path_schema,
+                ),
+                path,
+            )
 
     def write(
         self, tile: Optional[BufferedTile] = None, path: Optional[MPathLike] = None
@@ -498,7 +504,7 @@ class VRTFileWriter:
         # build XML
         E = ElementMaker()
         vrt = E.VRTDataset(
-            E.SRS(self._tp.crs.wkt),
+            E.SRS(self.pyramid.crs.wkt),
             E.GeoTransform(", ".join(map(str, vrt_affine.to_gdal()))),
             *[
                 E.VRTRasterBand(
@@ -523,12 +529,12 @@ class VRTFileWriter:
                                 DataType=vrt_dtype,
                                 BlockXSize=str(
                                     self._output.profile().get(
-                                        "blockxsize", self._tp.tile_size
+                                        "blockxsize", self.pyramid.tile_size
                                     )
                                 ),
                                 BlockYSize=str(
                                     self._output.profile().get(
-                                        "blockysize", self._tp.tile_size
+                                        "blockysize", self.pyramid.tile_size
                                     )
                                 ),
                             ),

--- a/mapchete/index.py
+++ b/mapchete/index.py
@@ -37,8 +37,6 @@ from mapchete.config.parse import get_zoom_levels
 from mapchete.io import (
     MPath,
     fiona_open,
-    fs_from_path,
-    path_exists,
     raster,
     rasterio_open,
     relative_path,
@@ -324,22 +322,23 @@ class VectorFileWriter:
 class TextFileWriter:
     """Writes tile paths into text file."""
 
+    path: MPath
+
     def __init__(self, out_path: MPathLike):
-        self.path = out_path
+        self.path = MPath.from_inp(out_path)
         logger.debug("initialize TXT writer")
-        self.fs = fs_from_path(out_path)
-        if path_exists(self.path):
-            with self.fs.open(self.path, "r") as src:
+        if self.path.exists():
+            with self.path.open("r") as src:
                 self._existing = {line for line in src.readlines()}
         else:
             self._existing = {}
         self.new_entries = 0
-        self.sink = self.fs.open(self.path, "w")
+        self.sink = self.path.open("w")
         for line in self._existing:
             self._write_line(line)
 
     def __repr__(self):  # pragma: no cover
-        return "TextFileWriter(%s)" % self.path
+        return f"TextFileWriter({str(self.path)})"
 
     def __enter__(self):
         return self
@@ -373,18 +372,19 @@ class TextFileWriter:
 class VRTFileWriter:
     """Generates GDAL-style VRT file."""
 
+    path: MPath
+
     def __init__(
         self, out_path: MPathLike, output: Any, out_pyramid: BufferedTilePyramid
     ):
         # see if lxml is installed before checking all output tiles
 
-        self.path = out_path
+        self.path = MPath.from_inp(out_path)
         self._tp = out_pyramid
         self._output = output
-        self.fs = fs_from_path(out_path)
         logger.debug("initialize VRT writer for %s", self.path)
-        if path_exists(self.path):
-            with self.fs.open(self.path) as src:
+        if self.path.exists():
+            with self.path.open() as src:
                 self._existing = {
                     k: MPath.from_inp(v) for k, v in self._xml_to_entries(src.read())
                 }
@@ -531,7 +531,7 @@ class VRTFileWriter:
         # generate pretty XML and write
         xmlstr = minidom.parseString(ET.tostring(vrt)).toprettyxml(indent="  ")
         logger.debug("write to %s", self.path)
-        with self.fs.open(self.path, "w") as dst:
+        with self.path.open("w") as dst:
             dst.write(xmlstr)
 
 
@@ -573,7 +573,8 @@ class RasterIndexWriter:
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
-        self.dump(self.reload_before_write)
+        if exc_type is None:
+            self.dump(self.reload_before_write)
 
     def reload(self) -> np.ndarray:
         """Reloads existing index if it exists and combines it with current array."""

--- a/mapchete/io/__init__.py
+++ b/mapchete/io/__init__.py
@@ -20,6 +20,7 @@ from mapchete.path import (
     path_is_remote,
     relative_path,
     tiles_exist,
+    all_existing_output_tiles,
 )
 from mapchete.settings import GDALHTTPOptions
 
@@ -34,6 +35,7 @@ __all__ = [
     "path_is_remote",
     "path_exists",
     "tiles_exist",
+    "all_existing_output_tiles",
     "absolute_path",
     "relative_path",
     "makedirs",

--- a/mapchete/path.py
+++ b/mapchete/path.py
@@ -855,9 +855,9 @@ class MPath(os.PathLike):
         started = time.time()
 
         # wait if there is an existing lockfile
-        while lockfile.exists():
+        while lockfile.exists():  # pragma: no cover
             elapsed = time.time() - started
-            if elapsed > timeout:  # pragma: no cover
+            if elapsed > timeout:
                 raise TimeoutError(
                     f"lockfile {str(lockfile)} exists for longer than {pretty_seconds(elapsed)}"
                 )

--- a/mapchete/path.py
+++ b/mapchete/path.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 import hashlib
 import json
 import logging
@@ -11,11 +12,13 @@ from collections import defaultdict
 from datetime import datetime
 from functools import cached_property
 from io import TextIOWrapper
+import time
 from typing import (
     IO,
     Any,
     Dict,
     Generator,
+    Iterator,
     List,
     Optional,
     Set,
@@ -36,7 +39,7 @@ from rasterio.session import Session as RioSession
 from retry.api import retry_call
 
 from mapchete.executor import Executor
-from mapchete.pretty import pretty_bytes
+from mapchete.pretty import pretty_bytes, pretty_seconds
 from mapchete.protocols import ObserverProtocol
 from mapchete.settings import GDALHTTPOptions, IORetrySettings, mapchete_options
 from mapchete.tile import BatchBy, BufferedTile
@@ -841,6 +844,48 @@ class MPath(os.PathLike):
                 opts=opts, allowed_remote_extensions=allowed_remote_extensions
             )
         )
+
+    def wait_for_lock(
+        self,
+        postfix: str = ".lock",
+        wait_interval_seconds: float = 1.0,
+        timeout: float = 30.0,
+    ) -> None:
+        lockfile = self + postfix
+        started = time.time()
+
+        # wait if there is an existing lockfile
+        while lockfile.exists():
+            elapsed = time.time() - started
+            if elapsed > timeout:  # pragma: no cover
+                raise TimeoutError(
+                    f"lockfile {str(lockfile)} exists for longer than {pretty_seconds(elapsed)}"
+                )
+            logger.debug(
+                "%s exists, waiting for %s",
+                str(lockfile),
+                pretty_seconds(wait_interval_seconds),
+            )
+            time.sleep(wait_interval_seconds)
+
+    @contextmanager
+    def lock(
+        self, postfix: str = ".lock", wait_interval_seconds: float = 1.0
+    ) -> Iterator[MPath]:
+        """Locks this path but wait if there is an existing lock."""
+        lockfile = self + postfix
+
+        # wait if there is an existing lockfile
+        self.wait_for_lock(postfix=postfix, wait_interval_seconds=wait_interval_seconds)
+
+        # create lockfile and only delete when context manager closes
+        try:
+            logger.debug("create lockfile %s", str(lockfile))
+            lockfile.write_content(b"")
+            yield lockfile
+        finally:
+            lockfile.rm(ignore_errors=True)
+            logger.debug("deleted lockfile %s", str(lockfile))
 
     def __truediv__(self, other: MPathLike) -> MPath:
         """Short for self.joinpath()."""

--- a/mapchete/path.py
+++ b/mapchete/path.py
@@ -42,7 +42,7 @@ from mapchete.executor import Executor
 from mapchete.pretty import pretty_bytes, pretty_seconds
 from mapchete.protocols import ObserverProtocol
 from mapchete.settings import GDALHTTPOptions, IORetrySettings, mapchete_options
-from mapchete.tile import BatchBy, BufferedTile
+from mapchete.tile import BatchBy, BufferedTile, BufferedTilePyramid
 from mapchete.timer import Timer
 from mapchete.types import MPathLike, Progress
 
@@ -1122,6 +1122,26 @@ def tiles_exist(
         yield from _output_tiles_batches_exist(
             output_tiles_batches, config, is_https_without_ls
         )
+
+
+def all_existing_output_tiles(config, zoom: int) -> Generator[BufferedTile, None, None]:
+    basepath: MPath = config.output_reader.path
+    # for single file outputs:
+    if basepath.suffix == config.output_reader.file_extension:
+        raise NotImplementedError()
+
+    # for tile directory outputs:
+    zoom_directory = basepath / zoom
+    for page in zoom_directory.paginate():
+        for path in page:
+            try:
+                yield _path_to_tile(path, config.output_reader.pyramid)
+            except ValueError:
+                logger.debug("invalid tile path found: %s", str(path))
+
+
+def _path_to_tile(path: MPath, pyramid: BufferedTilePyramid):
+    return pyramid.tile(*map(int, MPath.from_inp(path).without_suffix().elements[-3:]))
 
 
 def _is_https_without_ls(path: MPath, default_file: str = "metadata.json") -> bool:

--- a/mapchete/path.py
+++ b/mapchete/path.py
@@ -1135,7 +1135,11 @@ def all_existing_output_tiles(config, zoom: int) -> Generator[BufferedTile, None
     for page in zoom_directory.paginate():
         for path in page:
             try:
-                yield path_to_tile(path, config.output_reader.pyramid)
+                yield path_to_tile(
+                    path,
+                    config.output_reader.pyramid,
+                    tile_path_schema=config.output_reader.tile_path_schema,
+                )
             except ValueError:
                 logger.debug("invalid tile path found: %s", str(path))
 

--- a/mapchete/path.py
+++ b/mapchete/path.py
@@ -1127,7 +1127,7 @@ def tiles_exist(
 def all_existing_output_tiles(config, zoom: int) -> Generator[BufferedTile, None, None]:
     basepath: MPath = config.output_reader.path
     # for single file outputs:
-    if basepath.suffix == config.output_reader.file_extension:
+    if basepath.suffix == config.output_reader.file_extension:  # pragma: no cover
         raise NotImplementedError()
 
     # for tile directory outputs:
@@ -1135,13 +1135,35 @@ def all_existing_output_tiles(config, zoom: int) -> Generator[BufferedTile, None
     for page in zoom_directory.paginate():
         for path in page:
             try:
-                yield _path_to_tile(path, config.output_reader.pyramid)
+                yield path_to_tile(path, config.output_reader.pyramid)
             except ValueError:
                 logger.debug("invalid tile path found: %s", str(path))
 
 
-def _path_to_tile(path: MPath, pyramid: BufferedTilePyramid):
-    return pyramid.tile(*map(int, MPath.from_inp(path).without_suffix().elements[-3:]))
+def path_to_tile(
+    path: MPath,
+    pyramid: BufferedTilePyramid,
+    tile_path_schema: str = "{zoom}/{row}/{col}.{extension}",
+):
+    # figure out order of zoom, row, col based on schema
+    required_elements = {"zoom", "row", "col"}
+    keys = tuple(
+        element.lstrip("{").rstrip("}")
+        for element in tile_path_schema.split(".")[0].split("/")
+    )
+    if (
+        set(keys).intersection(required_elements) != required_elements
+    ):  # pragma: no cover
+        raise ValueError(
+            f"tile path schema does not contain all required elements (zoom, row, col): {tile_path_schema}"
+        )
+
+    return pyramid.tile(
+        **{
+            key: value
+            for key, value in zip(keys, map(int, path.without_suffix().elements[-3:]))
+        }
+    )
 
 
 def _is_https_without_ls(path: MPath, default_file: str = "metadata.json") -> bool:

--- a/mapchete/path.py
+++ b/mapchete/path.py
@@ -433,6 +433,7 @@ class MPath(os.PathLike):
 
     @_retry
     def write_content(self, content: Union[str, bytes], mode: str = "wb") -> None:
+        self.parent.makedirs()
         with self.fs.open(self._path_str, mode) as dst:
             dst.write(content)  # type: ignore
 
@@ -1127,18 +1128,19 @@ def _is_https_without_ls(path: MPath, default_file: str = "metadata.json") -> bo
     # Some HTTP endpoints won't allow ls() on them, so we will have to
     # request tile by tile in order to determine whether they exist or not.
     # This flag will trigger this further down.
-    is_https_without_ls = False
     if "https" in path.protocols:
         try:
             path.ls()
+            return False
         except FileNotFoundError:  # pragma: no cover
             metadata_json = path / default_file
             if not metadata_json.exists():
                 raise FileNotFoundError(
                     f"TileDirectory does not seem to exist or {default_file} is not available: {path}"
                 )
-            is_https_without_ls = True
-    return is_https_without_ls
+            return True
+    else:
+        return False
 
 
 def _batch_tiles_by_attribute(

--- a/test/commands/test_index.py
+++ b/test/commands/test_index.py
@@ -2,6 +2,7 @@ import pytest
 
 import mapchete
 from mapchete.commands import execute, index
+from mapchete.io.raster import ReferencedRaster
 from mapchete.io.vector import fiona_open
 
 
@@ -245,6 +246,20 @@ def test_index_tiledir(cleantopo_br):
         for feature in src:
             assert "location" in feature["properties"]
         assert len(list(src)) == 2
+
+
+def test_index_tif(cleantopo_br):
+    # execute process
+    execute(cleantopo_br.dict, zoom=5)
+
+    # generate index
+    index(cleantopo_br.dict, zoom=5, tif=True)
+
+    with mapchete.open(cleantopo_br.dict) as mp:
+        files = mp.config.output.path.ls(absolute_paths=False)
+        assert "5.tif" in files
+    arr = ReferencedRaster.from_file(mp.config.output.path / "5.tif").array
+    assert arr.sum() == 2
 
 
 def test_index_errors(cleantopo_br):

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -4,8 +4,9 @@ import numpy as np
 import pytest
 
 import mapchete
-from mapchete.index import create_indexes
+from mapchete.index import create_indexes, RasterIndexWriter
 from mapchete.io import fiona_open, rasterio_open
+from mapchete.tile import BufferedTilePyramid
 
 
 @pytest.mark.integration
@@ -193,3 +194,32 @@ def test_vrt_mercator(cleantopo_br_mercator):
             out_dir=mp.config.output.path,
             vrt=True,
         )
+
+
+@pytest.mark.parametrize("grid", ["geodetic", "mercator"])
+def test_tif_index(mp_tmpdir, grid):
+    tile_pyramid = BufferedTilePyramid(grid)
+    zoom = 1
+    out_path = mp_tmpdir / f"{zoom}.tif"
+    with RasterIndexWriter(
+        out_path=out_path, out_pyramid=tile_pyramid, zoom=zoom, reload_before_write=True
+    ) as index:
+        assert index.array.sum() == 0
+        index.write(tile=tile_pyramid.tile(zoom, 0, 0))
+        assert index.array.sum() == 1
+
+        with RasterIndexWriter(
+            out_path=out_path,
+            out_pyramid=tile_pyramid,
+            zoom=zoom,
+            reload_before_write=True,
+        ) as another_index:
+            another_index.write(tile=tile_pyramid.tile(zoom, 0, 1))
+
+        assert index.array.sum() == 1
+        index.dump(reload_before_write=True)
+        assert index.array.sum() == 2
+
+    with rasterio_open(out_path) as src:
+        assert src.read().sum() == 2
+        assert src.crs == tile_pyramid.crs

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -17,7 +17,7 @@ def test_remote_indexes(gtiff_s3):
         # generate indexes
         list(
             zoom_index_gen(
-                mp=mp,
+                config=mp.config,
                 zoom=zoom,
                 out_dir=mp.config.output.path,
                 geojson=True,
@@ -63,7 +63,7 @@ def test_vrt(mp_tmpdir, cleantopo_br):
         # generate index
         list(
             zoom_index_gen(
-                mp=mp,
+                config=mp.config,
                 zoom=zoom,
                 out_dir=mp.config.output.path,
                 vrt=True,
@@ -119,7 +119,7 @@ def test_vrt(mp_tmpdir, cleantopo_br):
         # generate index
         list(
             zoom_index_gen(
-                mp=mp,
+                config=mp.config,
                 zoom=zoom,
                 out_dir=mp.config.output.path,
                 vrt=True,
@@ -138,7 +138,7 @@ def test_vrt_mercator(cleantopo_br_mercator):
         # generate index
         list(
             zoom_index_gen(
-                mp=mp,
+                config=mp.config,
                 zoom=zoom,
                 out_dir=mp.config.output.path,
                 vrt=True,
@@ -197,7 +197,7 @@ def test_vrt_mercator(cleantopo_br_mercator):
         # generate index
         list(
             zoom_index_gen(
-                mp=mp,
+                config=mp.config,
                 zoom=zoom,
                 out_dir=mp.config.output.path,
                 vrt=True,

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import mapchete
-from mapchete.index import zoom_index_gen
+from mapchete.index import create_indexes
 from mapchete.io import fiona_open, rasterio_open
 
 
@@ -15,15 +15,13 @@ def test_remote_indexes(gtiff_s3):
 
     def gen_indexes_and_check():
         # generate indexes
-        list(
-            zoom_index_gen(
-                config=mp.config,
-                zoom=zoom,
-                out_dir=mp.config.output.path,
-                geojson=True,
-                txt=True,
-                vrt=True,
-            )
+        create_indexes(
+            config=mp.config,
+            zoom=zoom,
+            out_dir=mp.config.output.path,
+            geojson=True,
+            txt=True,
+            vrt=True,
         )
 
         # assert GeoJSON exists
@@ -61,13 +59,11 @@ def test_vrt(mp_tmpdir, cleantopo_br):
         list(mp.execute(zoom=zoom))
 
         # generate index
-        list(
-            zoom_index_gen(
-                config=mp.config,
-                zoom=zoom,
-                out_dir=mp.config.output.path,
-                vrt=True,
-            )
+        create_indexes(
+            config=mp.config,
+            zoom=zoom,
+            out_dir=mp.config.output.path,
+            vrt=True,
         )
         output_tiles = list(
             mp.config.output_pyramid.tiles_from_bounds(
@@ -117,13 +113,11 @@ def test_vrt(mp_tmpdir, cleantopo_br):
         list(mp.execute(zoom=zoom))
 
         # generate index
-        list(
-            zoom_index_gen(
-                config=mp.config,
-                zoom=zoom,
-                out_dir=mp.config.output.path,
-                vrt=True,
-            )
+        create_indexes(
+            config=mp.config,
+            zoom=zoom,
+            out_dir=mp.config.output.path,
+            vrt=True,
         )
 
 
@@ -136,13 +130,11 @@ def test_vrt_mercator(cleantopo_br_mercator):
         list(mp.execute(zoom=zoom))
 
         # generate index
-        list(
-            zoom_index_gen(
-                config=mp.config,
-                zoom=zoom,
-                out_dir=mp.config.output.path,
-                vrt=True,
-            )
+        create_indexes(
+            config=mp.config,
+            zoom=zoom,
+            out_dir=mp.config.output.path,
+            vrt=True,
         )
         output_tiles = list(
             mp.config.output_pyramid.tiles_from_bounds(
@@ -195,11 +187,9 @@ def test_vrt_mercator(cleantopo_br_mercator):
         list(mp.execute(zoom=zoom))
 
         # generate index
-        list(
-            zoom_index_gen(
-                config=mp.config,
-                zoom=zoom,
-                out_dir=mp.config.output.path,
-                vrt=True,
-            )
+        create_indexes(
+            config=mp.config,
+            zoom=zoom,
+            out_dir=mp.config.output.path,
+            vrt=True,
         )

--- a/test/test_path.py
+++ b/test/test_path.py
@@ -6,7 +6,8 @@ from pytest_lazy_fixtures import lf as lazy_fixture
 
 from mapchete.config import get_hash
 from mapchete.io.raster.referenced_raster import ReferencedRaster
-from mapchete.path import MPath, batch_sort_property
+from mapchete.path import MPath, batch_sort_property, path_to_tile
+from mapchete.tile import BufferedTilePyramid
 
 
 @pytest.mark.parametrize(
@@ -625,3 +626,20 @@ def test_checksum(src_path: MPath):
         src_path.checksum()
         == "fff06260d08965a898021b9513dc9226f6c3b964d755734357603c21fb2359ad"
     )
+
+
+@pytest.mark.parametrize(
+    "path_control",
+    [
+        ("/foo/bar/3/1/2.tif", "{zoom}/{row}/{col}.{extension}", (3, 1, 2)),
+        ("/foo/bar/3/2/1.tif", "{zoom}/{col}/{row}.{extension}", (3, 1, 2)),
+        ("/foo/bar/2/3/1.tif", "{col}/{zoom}/{row}.{extension}", (3, 1, 2)),
+    ],
+)
+def test_path_to_tile(path_control):
+    path_str, tile_path_schema, control_id = path_control
+    pyramid = BufferedTilePyramid("geodetic")
+    tile = path_to_tile(
+        MPath.from_inp(path_str), pyramid=pyramid, tile_path_schema=tile_path_schema
+    )
+    assert tile.id == control_id


### PR DESCRIPTION
* enables writing GeoTIFFs in addition to vector and text files
* renamed `index.zoom_index_gen()` into `index.create_indexes()`
* `index.create_indexes()`: modernize by adding observers
* `path.MPath`: added `lock()` and `wait_for_lock()` methods
* added `path.all_existing_output_tiles()` and `path.path_to_tile()` functions
 